### PR TITLE
Replace use of pivot_root with mount and move.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,8 +15,8 @@
 - [ ] stage1: Add resource allocation
 - [ ] stage1: Re-enable user namespace functionality
 - [ ] Review Manager/Container lock handling
-- [ ] Look at a futex for protecting concurrent pivot_root calls.
 - [ ] Metadata API support
+- [X] Look at a futex for protecting concurrent pivot_root calls.
 - [X] cli: Add parameter for speciying a remote host to use
 - [X] stage3: Updated User/Group username/uid handling to 0.6.0 spec
 - [X] api: Implement remote API handling

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -53,7 +53,7 @@ func (r *runner) loadConfigurationFile() error {
 
 		// mount the disk
 		diskPath := filepath.Join(mountPath, strings.Replace(device, "/", "_", -1))
-		if err := handleMount(device, diskPath, fstype, ""); err != nil {
+		if err := handleMount(device, diskPath, fstype, 0, ""); err != nil {
 			r.log.Errorf("failed to mount oem config disk %q: %v", device, err)
 			return nil
 		}
@@ -133,7 +133,7 @@ func (r *runner) createSystemMounts() error {
 
 		// perform the mount
 		r.log.Tracef("- mounting %q (type %q) to %q", source, fstype, location)
-		if err := handleMount(source, location, fstype, ""); err != nil {
+		if err := handleMount(source, location, fstype, 0, ""); err != nil {
 			return fmt.Errorf("failed to mount %q: %v", location, err)
 		}
 	}
@@ -166,7 +166,7 @@ func (r *runner) mountCgroups() error {
 	for _, cgrouptype := range cgroupTypes {
 		location := filepath.Join(cgroupsMount, cgrouptype)
 		r.log.Tracef("- mounting cgroup %q to %q", cgrouptype, location)
-		if err := handleMount("none", location, "cgroup", cgrouptype); err != nil {
+		if err := handleMount("none", location, "cgroup", 0, cgrouptype); err != nil {
 			return fmt.Errorf("failed to mount cgroup %q: %v", cgrouptype, err)
 		}
 
@@ -255,7 +255,7 @@ func (r *runner) mountDisks() error {
 
 		// mount it
 		diskPath := filepath.Join(mountPath, strings.Replace(device, "/", "_", -1))
-		if err := handleMount(device, diskPath, fstype, ""); err != nil {
+		if err := handleMount(device, diskPath, fstype, 0, ""); err != nil {
 			r.log.Errorf("failed to mount disk %q: %v", device, err)
 			continue
 		}

--- a/init/utils.go
+++ b/init/utils.go
@@ -19,11 +19,11 @@ import (
 
 // handleMount takes care of creating the mount path and issuing the mount
 // syscall for the mount source, location, and fstype.
-func handleMount(source, location, fstype, data string) error {
+func handleMount(source, location, fstype string, flags uintptr, data string) error {
 	if err := os.MkdirAll(location, os.FileMode(0755)); err != nil {
 		return err
 	}
-	return syscall.Mount(source, location, fstype, syscall.MS_MGC_VAL, data)
+	return syscall.Mount(source, location, fstype, flags, data)
 }
 
 // bindMount does a bind mount for the source to also be accessible at the dest.

--- a/kurma-server.go
+++ b/kurma-server.go
@@ -20,6 +20,7 @@ func main() {
 	opts := &server.Options{
 		ParentCgroupName:   "kurma",
 		ContainerDirectory: directory,
+		RequiredNamespaces: []string{"ipc", "mount", "pid", "uts"},
 	}
 
 	s := server.New(opts)

--- a/stage1/server/server.go
+++ b/stage1/server/server.go
@@ -16,6 +16,7 @@ import (
 type Options struct {
 	ParentCgroupName   string
 	ContainerDirectory string
+	RequiredNamespaces []string
 	ContainerManager   *container.Manager
 }
 
@@ -76,6 +77,7 @@ func (s *Server) initializeManager() (*container.Manager, error) {
 	mopts := &container.Options{
 		ParentCgroupName:   s.options.ParentCgroupName,
 		ContainerDirectory: s.options.ContainerDirectory,
+		RequiredNamespaces: s.options.RequiredNamespaces,
 	}
 
 	m, err := container.NewManager(mopts)

--- a/stage2/clone.c
+++ b/stage2/clone.c
@@ -164,7 +164,7 @@ static void setup_container(clone_destination_data *args, pid_t uidmap_child) {
 		}
 		if (args->chroot) {
 			DEBUG("Chrooting into filesystem\n");
-			enterroot(args->privileged);
+			enterroot();
 		}
 
 		// --------------------------------------------------------------------

--- a/stage2/spawner.h
+++ b/stage2/spawner.h
@@ -120,7 +120,7 @@ int flags_for_clone(clone_destination_data *args);
 // mount.c
 char *tmpdir(void);
 void createroot(char *src, char *dst, bool privileged);
-void enterroot(bool privileged);
+void enterroot();
 void mountproc(void);
 
 // util.c

--- a/stage3/chroot_request.c
+++ b/stage3/chroot_request.c
@@ -11,11 +11,9 @@
 // Documented in cinitd.h
 void chroot_request(struct request *r)
 {
-	bool privileged;
-
 	// The expected protocol for a chroot statement looks like this:
 	// {
-	//   { "CHROOT" "DIRECTORY" "PRIVILEGED" },
+	//   { "CHROOT", "DIRECTORY" },
 	// }
 
 	INFO("[%d] CHROOT request.\n", r->fd);
@@ -25,8 +23,7 @@ void chroot_request(struct request *r)
 		(r->outer_len != 1) ||
 		// CHROOT
 		(r->data[0][1] == NULL) ||
-		(r->data[0][2] == NULL) ||
-		(r->data[0][3] != NULL) ||
+		(r->data[0][2] != NULL) ||
 		// END
 		(r->data[1] != NULL))
 	{
@@ -35,18 +32,15 @@ void chroot_request(struct request *r)
 		return;
 	}
 
-	// Check the privileged flag
-	privileged = (strncmp(r->data[0][2], "true", 5) == 0);
-
 	// Attempt the actual chroot.
-	if (pivot_root(r->data[0][1], privileged) != 0) {
-		ERROR("[%d] Failed to pivot_root('%s'): %s\n", r->fd, r->data[0][1], strerror(errno));
+	if (moveroot(r->data[0][1]) != 0) {
+		ERROR("[%d] Failed to chroot('%s'): %s\n", r->fd, r->data[0][1], strerror(errno));
 		initd_response_internal_error(r);
 		return;
 	}
 
 	// Success. Inform the caller.
-	INFO("[%d] Successful pivot_root('%s') and chdir('/'), responding OK.\n", r->fd, r->data[0][1]);
+	INFO("[%d] Successful chroot('%s') and chdir('/'), responding OK.\n", r->fd, r->data[0][1]);
 	initd_response_request_ok(r);
 }
 

--- a/stage3/cinitd.h
+++ b/stage3/cinitd.h
@@ -288,10 +288,9 @@ void close_all_fds();
 // Will print the time to current fd, e.g. stdout, stderr
 void server_print_time(FILE *fd);
 
-// Uses pivot_root to enter the root directory structure, chdir, and cleanup
-// after itself. It uses pivot_root instead of chroot to ensure cleaner
-// separation from the root mount namespace.
-int pivot_root(char *root, bool privileged);
+// Uses moveroot to enter the root directory structure, chdir, and cleanup
+// after itself.
+int moveroot(char *root);
 
 // Converts the string of the username into a UID for a process by either
 // looking up the username in /etc/passwd or by converting it to an integer if

--- a/stage3/client/client_test.go
+++ b/stage3/client/client_test.go
@@ -161,7 +161,7 @@ func TestClient_Chroot(t *testing.T) {
 	readChan := setupReadRequest(t, l, &chrootContent, "REQUEST OK\n")
 
 	client := New(socketFile)
-	err := client.Chroot("/chroot", false, time.Second)
+	err := client.Chroot("/chroot", time.Second)
 	tt.TestExpectSuccess(t, err)
 
 	select {
@@ -170,7 +170,7 @@ func TestClient_Chroot(t *testing.T) {
 		tt.Fatalf(t, "Expected to have read client response within 1 second")
 	}
 
-	expectedRequest := "1\n1\n3\n6\nCHROOT7\n/chroot5\nfalse"
+	expectedRequest := "1\n1\n2\n6\nCHROOT7\n/chroot"
 	tt.TestEqual(t, chrootContent, expectedRequest)
 }
 
@@ -224,6 +224,30 @@ func TestClient_Start(t *testing.T) {
 	}
 
 	expectedRequest := "1\n6\n2\n5\nSTART4\necho1\n3\n1231\n3\ndir1\n7\nFOO=bar2\n2\n/a2\n/b2\n3\n1233\n456"
+	tt.TestEqual(t, startContent, expectedRequest)
+}
+
+func TestClient_Mount(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	socketFile, l := createSocketServer(t)
+	defer l.Close()
+
+	var startContent string
+	readChan := setupReadRequest(t, l, &startContent, "REQUEST OK\n")
+
+	client := New(socketFile)
+	err := client.Mount("/src", "/dst", "ext4", 0, "", time.Second)
+	tt.TestExpectSuccess(t, err)
+
+	select {
+	case <-readChan:
+	case <-time.After(time.Second):
+		tt.Fatalf(t, "Expected to have read client response within 1 second")
+	}
+
+	expectedRequest := "1\n2\n3\n5\nMOUNT4\n/src4\n/dst3\n4\next41\n00\n"
 	tt.TestEqual(t, startContent, expectedRequest)
 }
 

--- a/stage3/helpers.c
+++ b/stage3/helpers.c
@@ -203,21 +203,19 @@ void initd_setup_fds(char *stdout_fn, char *stderr_fn)
 }
 
 // Documented in cinitd.h
-int pivot_root(char *root, bool privileged) {
+int moveroot(char *root) {
 	if (chdir(root) < 0)
 		return -1;
-	if (mkdir("host", 0755) < 0)
+
+	if (mount (root, root, NULL, MS_BIND | MS_REC, NULL) < 0)
 		return -1;
-	if (syscall(__NR_pivot_root, ".", "host") < 0)
+	if (mount (root, "/", NULL, MS_MOVE, NULL) < 0)
+		return -1;
+	if (chroot (".") < 0)
 		return -1;
 	if (chdir("/") < 0)
 		return -1;
 
-	if (!privileged) {
-		if(umount2("/host", MNT_DETACH) < 0)
-			return -1;
-		rmdir("/host");
-	}
 	return 0;
 }
 

--- a/stage3/mount_request.c
+++ b/stage3/mount_request.c
@@ -1,0 +1,61 @@
+// Copyright 2013-2015 Apcera Inc. All rights reserved.
+
+#ifndef INITD_SERVER_MOUNT_REQUEST_C
+#define INITD_SERVER_MOUNT_REQUEST_C
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/stat.h>
+#include <sys/mount.h>
+
+#include "cinitd.h"
+
+// Documented in cinitd.h
+void mount_request(struct request *r)
+{
+	unsigned long flags;
+
+	// The expected protocol for a mount statement looks like this:
+	// {
+	//   { "MOUNT", "HOST DIRECTORY", "CONTAINER PATH" },
+	//   { "FSTYPE", "FLAGS", "DATA" }
+	// }
+
+	INFO("[%d] MOUNT request.\n", r->fd);
+
+	// Protocol error conditions.
+	if (
+		(r->outer_len != 2) ||
+		// MOUNT
+		(r->data[0][1] == NULL) ||
+		(r->data[0][2] == NULL) ||
+		(r->data[0][3] != NULL) ||
+		// FSTYPE (nullable), FLAGS, DATA (nullable)
+		(r->data[1][1] == NULL) ||
+		(r->data[1][3] != NULL) ||
+		// END
+		(r->data[2] != NULL))
+	{
+		INFO("[%d] Protocol error.\n", r->fd);
+		initd_response_protocol_error(r);
+		return;
+	}
+
+	// Convert the flags
+	flags = atol(r->data[1][1]);
+
+	// Attempt the mount.
+	if (mount(r->data[0][1], r->data[0][2], r->data[1][0], flags, r->data[1][2]) != 0) {
+		ERROR("[%d] Failed to mount('%s', '%s'): %s\n", r->fd, r->data[0][1], r->data[0][2], strerror(errno));
+		initd_response_internal_error(r);
+		return;
+	}
+
+	// Success. Inform the caller.
+	INFO("[%d] Successful mount('%s', '%s'), responding OK.\n", r->fd, r->data[0][1], r->data[0][2]);
+	initd_response_request_ok(r);
+}
+
+#endif

--- a/stage3/mount_request_test.go
+++ b/stage3/mount_request_test.go
@@ -1,0 +1,105 @@
+// Copyright 2013-2015 Apcera Inc. All rights reserved.
+
+// +build linux,cgo
+
+package stage3_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/apcera/util/uuid"
+
+	. "github.com/apcera/util/testtool"
+)
+
+func TestMountRequest(t *testing.T) {
+	StartTest(t)
+	defer FinishTest(t)
+	TestRequiresRoot(t)
+
+	// Start the initd process.
+	_, socket, _, pid := StartInitd(t)
+
+	content := uuid.Variant4().String()
+
+	tempDir, err := ioutil.TempDir("/var", "container"+uuid.Variant4().String())
+	TestExpectSuccess(t, err)
+	AddTestFinalizer(func() { os.RemoveAll(tempDir) })
+	err = os.Chmod(tempDir, os.FileMode(0755))
+	TestExpectSuccess(t, err)
+	TestExpectSuccess(t, ioutil.WriteFile(filepath.Join(tempDir, "foo"), []byte(content), os.FileMode(0644)))
+
+	otherTempDir, err := ioutil.TempDir("/var", "container"+uuid.Variant4().String())
+	TestExpectSuccess(t, err)
+	AddTestFinalizer(func() { os.RemoveAll(otherTempDir) })
+
+	request := [][]string{
+		[]string{"MOUNT", tempDir, otherTempDir},
+		[]string{"", fmt.Sprintf("%d", syscall.MS_BIND), ""},
+	}
+	reply, err := MakeRequest(socket, request, 10*time.Second)
+	TestExpectSuccess(t, err)
+	TestEqual(t, reply, "REQUEST OK\n")
+
+	// Next check to see that the init daemon is mounted the path correctly.
+	contents, err := ioutil.ReadFile(filepath.Join(fmt.Sprintf("/proc/%d/root", pid), otherTempDir, "foo"))
+	TestExpectSuccess(t, err)
+	TestEqual(t, string(contents), content)
+}
+
+func TestBadMountRequest(t *testing.T) {
+	StartTest(t)
+	defer FinishTest(t)
+	TestRequiresRoot(t)
+
+	tests := [][][]string{
+		// Test 1: Request is too short.
+		[][]string{
+			[]string{"MOUNT", "SRC", "DST"},
+		},
+
+		// Test 2: Request is too long..
+		[][]string{
+			[]string{"MOUNT", "SRC", "DST"},
+			[]string{"FS", "FLAGS", ""},
+			[]string{},
+		},
+
+		// Test 3: Extra cruft after DST
+		[][]string{
+			[]string{"MOUNT", "SRC", "DST", "EXTRA"},
+			[]string{"FS", "0", ""},
+		},
+
+		// Test 4: Extra cruft after CREATE
+		[][]string{
+			[]string{"MOUNT", "SRC", "DST"},
+			[]string{"FS", "0", "", "EXTRA"},
+		},
+
+		// Test 5: Missing SRC
+		[][]string{
+			[]string{"MOUNT", "", "DST"},
+			[]string{"FS", "0", ""},
+		},
+
+		// Test 6: Missing DST
+		[][]string{
+			[]string{"MOUNT", "SRC"},
+			[]string{"FS", "0", ""},
+		},
+
+		// Test 7: Missing FLAGS
+		[][]string{
+			[]string{"MOUNT", "SRC", "DST"},
+			[]string{"FS", "", ""},
+		},
+	}
+	BadResultsCheck(t, tests)
+}

--- a/stage3/request.c
+++ b/stage3/request.c
@@ -242,6 +242,8 @@ static int outer_done(struct request *r)
 		exec_request(r);
 	} else if (!strncmp(r->data[0][0], "START", 6)) {
 		start_request(r);
+	} else if (!strncmp(r->data[0][0], "MOUNT", 6)) {
+		mount_request(r);
 	} else if (!strncmp(r->data[0][0], "STATUS", 7)) {
 		status_request(r);
 	} else if (!strncmp(r->data[0][0], "WAIT", 5)) {


### PR DESCRIPTION
This changes the way the filesystem is scoped from using pivot_root to instead
bind mount the directory over itself, and then move it to the root. This
approach is simpler and less black magic than pivot_root, and also resolves
the issue we've seen before where multiple contains calling pivot_root at the
same time is racey.

This also changes how host filesystem access is setup in privileged mode.
Previously, it just left the old host filesystem mounted with pivot_root.

Now, have added a new MOUNT command to the stage3 init process. With this, the
stage1 can ask the stage3 to perform the bind mounts before it performs the
chroot.

It will now set up /host/pods going directly to the pods filesystem (read-
only). It will also set up /host/proc to be the proc partition of the host.
Note the comment regarding it overall not being read-only, mostly due to
limitations in fully enforcing read-only through things like traversing
/proc/pid/root to processes root not maintaining read-only state.

FYI PR