### PR TITLE
Change direct API from TCP to unix socket based.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,6 @@
 - [ ] cli: Implement specifying the container name
 - [ ] init: Add ability for arbitruary configuration to be passed to initial
   containers.
-- [ ] stage1: Move local API to use a unix socket rather than localhost.
-- [ ] stage1: Support volumes
 - [ ] stage1: Implement hook calls
 - [ ] stage1: Implement appc isolators for capabilities
 - [ ] stage1: Implement appc isolators for cgroups
@@ -16,6 +14,8 @@
 - [ ] stage1: Re-enable user namespace functionality
 - [ ] Review Manager/Container lock handling
 - [ ] Metadata API support
+- [X] stage1: Move local API to use a unix socket rather than localhost.
+- [X] stage1: Support volumes
 - [X] Look at a futex for protecting concurrent pivot_root calls.
 - [X] cli: Add parameter for speciying a remote host to use
 - [X] stage3: Updated User/Group username/uid handling to 0.6.0 spec
@@ -38,10 +38,10 @@
 - [ ] Multiple apps in a single pod
 - [ ] Configurable configuration datasources
 - [ ] Add whitelist support for where to retrieve an image from
-- [ ] Add baseline enforcement of certain kernel namespaces, like mount, ipc,
-  and pid.
 - [ ] Have enter command look up user shell if none is given and use that for
   exec
+- [X] Add baseline enforcement of certain kernel namespaces, like mount, ipc,
+  and pid.
 - [X] Add support for image retrieval through an http proxy
 - [X] Kernel module scoping for each environment
 

--- a/client/api/server.go
+++ b/client/api/server.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"net"
+	"time"
 
 	pb "github.com/apcera/kurma/stage1/client"
 	"github.com/apcera/logray"
@@ -47,7 +48,10 @@ func (s *Server) Start() error {
 	defer l.Close()
 
 	// create the client RPC connection to the host
-	conn, err := grpc.Dial("127.0.0.1:12311", grpc.WithInsecure())
+	dialer := func(addr string, timeout time.Duration) (net.Conn, error) {
+		return net.DialTimeout("unix", addr, timeout)
+	}
+	conn, err := grpc.Dial("/var/lib/kurma.sock", grpc.WithDialer(dialer), grpc.WithInsecure())
 	if err != nil {
 		return err
 	}

--- a/client/api/validation.go
+++ b/client/api/validation.go
@@ -24,6 +24,16 @@ func validateImageManifest(imageManifest *schema.ImageManifest) error {
 		}
 	}
 
+	// Reject any containers that request host API access. This can only be
+	// started with the local API, not remote API.
+	if iso := imageManifest.App.Isolators.GetByName(kschema.HostApiAccessName); iso != nil {
+		if piso, ok := iso.Value().(*kschema.HostApiAccess); ok {
+			if *piso {
+				return fmt.Errorf("host API access containers cannot be launched remotely")
+			}
+		}
+	}
+
 	// FIXME once network isolation is in, this should force adding the container
 	// namespaces isolator to ensure any remotely sourced images are network
 	// namespaced.

--- a/client/cli/cli.go
+++ b/client/cli/cli.go
@@ -15,7 +15,6 @@ const (
 	defaultConfirmation = "Is this correct?"
 	askYes              = "Y/n"
 	askNo               = "y/N"
-	defaultKurmaIP      = "127.0.0.1"
 )
 
 var (
@@ -105,6 +104,6 @@ func addGlobalFlags(f *flag.FlagSet) {
 	f.BoolVar(&ShowVersion, "version", false, "")
 	f.BoolVar(&ShowVersion, "ver", false, "")
 	f.BoolVar(&ShowVersion, "v", false, "")
-	f.StringVar(&KurmaHost, "host", defaultKurmaIP, "")
-	f.StringVar(&KurmaHost, "H", defaultKurmaIP, "")
+	f.StringVar(&KurmaHost, "host", "", "")
+	f.StringVar(&KurmaHost, "H", "", "")
 }

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -474,12 +474,22 @@ func (r *runner) startSignalHandling() error {
 
 // startServer begins the main Kurma RPC server and will take over execution.
 func (r *runner) startServer() error {
+	perms := os.FileMode(0770)
+	group := 200
+
 	opts := &server.Options{
-		ContainerManager: r.manager,
+		ContainerManager:  r.manager,
+		SocketFile:        filepath.Join(kurmaPath, "socket"),
+		SocketPermissions: &perms,
+		SocketGroup:       &group,
 	}
 
 	s := server.New(opts)
-	go s.Start()
+	go func() {
+		if err := s.Start(); err != nil {
+			r.log.Errorf("Error with Kurma server: %v", err)
+		}
+	}()
 	return nil
 }
 

--- a/kurma-server.go
+++ b/kurma-server.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/apcera/kurma/stage1/server"
@@ -12,6 +13,11 @@ import (
 )
 
 func main() {
+	var socketfile, parentCgroupName string
+	flag.StringVar(&parentCgroupName, "cgroup", "kurma", "Name of the cgroup to create")
+	flag.StringVar(&socketfile, "socket", "kurma.sock", "Socket file to create")
+	flag.Parse()
+
 	logray.AddDefaultOutput("stdout://", logray.ALL)
 
 	directory, err := os.Getwd()
@@ -20,9 +26,10 @@ func main() {
 	}
 
 	opts := &server.Options{
-		ParentCgroupName:   "kurma",
+		ParentCgroupName:   parentCgroupName,
 		ContainerDirectory: directory,
 		RequiredNamespaces: []string{"ipc", "mount", "pid", "uts"},
+		SocketFile:         socketfile,
 	}
 
 	s := server.New(opts)

--- a/schema/isolator_host_api_access.go
+++ b/schema/isolator_host_api_access.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package schema
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema/types"
+)
+
+const (
+	HostApiAccessName = "host/api-access"
+)
+
+func init() {
+	types.AddIsolatorValueConstructor(HostApiAccessName, newHostApiAccess)
+}
+
+func newHostApiAccess() types.IsolatorValue {
+	n := HostApiAccess(false)
+	return &n
+}
+
+type HostApiAccess bool
+
+func (n *HostApiAccess) UnmarshalJSON(b []byte) error {
+	priv := false
+	if err := json.Unmarshal(b, &priv); err != nil {
+		return err
+	}
+	*n = HostApiAccess(priv)
+	return nil
+}
+
+func (n HostApiAccess) AssertValid() error {
+	return nil
+}

--- a/stage1/container/container_isolators.go
+++ b/stage1/container/container_isolators.go
@@ -1,0 +1,162 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package container
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	kschema "github.com/apcera/kurma/schema"
+	"github.com/apcera/kurma/stage3/client"
+)
+
+// setupLinuxNamespaceIsolator handles configuring the container for the
+// namespaces it is intended to have.
+func (c *Container) setupLinuxNamespaceIsolator(launcher *client.Launcher) error {
+	// Configure which linux namespaces to create
+	nsisolators := false
+	if iso := c.image.App.Isolators.GetByName(kschema.LinuxNamespacesName); iso != nil {
+		if niso, ok := iso.Value().(*kschema.LinuxNamespaces); ok {
+			launcher.NewIPCNamespace = niso.IPC()
+			launcher.NewMountNamespace = niso.Mount()
+			launcher.NewNetworkNamespace = niso.Net()
+			launcher.NewPIDNamespace = niso.PID()
+			launcher.NewUserNamespace = niso.User()
+			launcher.NewUTSNamespace = niso.UTS()
+			nsisolators = true
+		}
+	}
+	if !nsisolators {
+		// set some defaults if no namespace isolator was given
+		launcher.NewIPCNamespace = true
+		launcher.NewMountNamespace = true
+		launcher.NewPIDNamespace = true
+		launcher.NewUTSNamespace = true
+	}
+	return nil
+}
+
+// setupHostPrivilegeIsolator instruments the host access, if the container has
+// the host access isolator.
+func (c *Container) setupHostPrivilegeIsolator(launcher *client.Launcher) error {
+	// Check for a privileged isolator
+	if iso := c.image.App.Isolators.GetByName(kschema.HostPrivilegedName); iso != nil {
+		if piso, ok := iso.Value().(*kschema.HostPrivileged); ok {
+			if *piso {
+				launcher.HostPrivileged = true
+
+				// create the mount point
+				podsDest, err := c.ensureContainerPathExists("host/pods")
+				if err != nil {
+					return err
+				}
+				procDest, err := c.ensureContainerPathExists("host/proc")
+				if err != nil {
+					return err
+				}
+
+				podsMount := strings.Replace(podsDest, c.stage3Path(), client.DefaultChrootPath, 1)
+				procMount := strings.Replace(procDest, c.stage3Path(), client.DefaultChrootPath, 1)
+
+				// create the mount point definitions for host access
+				launcher.MountPoints = []*client.MountPoint{
+					// Add the pods mount
+					&client.MountPoint{
+						Source:      c.manager.containerDirectory,
+						Destination: podsMount,
+						Flags:       syscall.MS_BIND,
+					},
+					// Make the pods mount read only. This cannot be done all in one, and
+					// needs MS_BIND included to avoid "resource busy" and to ensure we're
+					// only making the bind location read-only, not the parent.
+					&client.MountPoint{
+						Source:      podsMount,
+						Destination: podsMount,
+						Flags:       syscall.MS_BIND | syscall.MS_REMOUNT | syscall.MS_RDONLY,
+					},
+
+					// Add the host's proc filesystem under host/proc. This can be done
+					// for diagnostics of the host's state, and can also be used to get
+					// access to the host's filesystem (via /host/proc/1/root/...). This
+					// is not read-only because making it read only isn't effective. You
+					// can still traverse into .../root/... partitions due to the magic
+					// that is proc and namespaces. Using proc is more useful than root
+					// because it ensures more consistent access to process's actual
+					// filesystem state as it crosses namespaces. Direct bind mounts tend
+					// to miss some child mounts, even when trying to ensure everything is
+					// shared.
+					&client.MountPoint{
+						Source:      "/proc",
+						Destination: procMount,
+						Flags:       syscall.MS_BIND,
+					},
+				}
+
+				// If a volume directory is defined, then map it in as well.
+				if c.manager.volumeDirectory != "" {
+					volumesDest, err := c.ensureContainerPathExists("host/volumes")
+					if err != nil {
+						return err
+					}
+					volumesMount := strings.Replace(volumesDest, c.stage3Path(), client.DefaultChrootPath, 1)
+					launcher.MountPoints = append(launcher.MountPoints,
+						&client.MountPoint{
+							Source:      c.manager.volumeDirectory,
+							Destination: volumesMount,
+							Flags:       syscall.MS_BIND,
+						})
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// setupHostApiAccessIsolator configures the container for API access over
+// Kurma's unix socket by bind mounting it into the container.
+func (c *Container) setupHostApiAccessIsolator(launcher *client.Launcher) error {
+	// Check if the container should have host API access via the socket file
+	if iso := c.image.App.Isolators.GetByName(kschema.HostApiAccessName); iso != nil {
+		if piso, ok := iso.Value().(*kschema.HostApiAccess); ok {
+			if *piso {
+				// find the relative path to the container, ensure it exists
+				dest, err := c.ensureContainerPathExists("var/lib")
+				if err != nil {
+					return err
+				}
+
+				// create the destination file that we'll bind mount
+				f, err := os.Create(filepath.Join(dest, "kurma.sock"))
+				if err != nil {
+					return err
+				}
+				f.Close()
+
+				// stat the socket file, get its group, and add it to supplemental GIDs
+				// for the container.
+				fi, err := os.Stat(c.manager.HostSocketFile)
+				if err != nil {
+					return fmt.Errorf("failed to stat the server socket file: %v", err)
+				}
+				c.image.App.SupplementaryGIDs = append(c.image.App.SupplementaryGIDs,
+					int(fi.Sys().(*syscall.Stat_t).Gid))
+
+				// find the container relative path, pre-chroot, and setup the mount
+				m := strings.Replace(dest, c.stage3Path(), client.DefaultChrootPath, 1)
+				launcher.Debug = true
+				launcher.MountPoints = append(launcher.MountPoints,
+					&client.MountPoint{
+						Source:      c.manager.HostSocketFile,
+						Destination: filepath.Join(m, "kurma.sock"),
+						Flags:       syscall.MS_BIND,
+					})
+			}
+		}
+	}
+
+	return nil
+}

--- a/stage1/container/manager.go
+++ b/stage1/container/manager.go
@@ -40,6 +40,8 @@ type Manager struct {
 	cgroup             *cgroups.Cgroup
 	containerDirectory string
 	requiredNamespaces []string
+
+	HostSocketFile string
 }
 
 // NewManager creates a new Manager with the provided options. It will ensure


### PR DESCRIPTION
This changes the core Kurma process to use a unix socket for all API access.
This allows the API to be isolated rather than having to rely on notions of
authentication.

Locally, a Kurma process should only be launching very trusted containers and
giving them host API access. Or, the process launching a container for host API
access itself has API access, so Kurma is trusting it.

Generally, if a container process has API access, it should be trusted. This is
one of the base ideas of Kurma as a base building block, and with some initial
trusted containers layering on logic about a broader cluster, and it defining
what the local host should trust or not.

The kurma-api process has been updated to proxy to the local host unix socket
from its TCP socket. It also rejects any container requesting host API access.

The kurma-cli has been updated to default to using the unix socket.