### PR TITLE
client/stage1: Add support for the "enter" command to be passed in the command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,8 +38,7 @@
 - [ ] Multiple apps in a single pod
 - [ ] Configurable configuration datasources
 - [ ] Add whitelist support for where to retrieve an image from
-- [ ] Have enter command look up user shell if none is given and use that for
-  exec
+- [X] Have enter command pass in the command to run
 - [X] Add baseline enforcement of certain kernel namespaces, like mount, ipc,
   and pid.
 - [X] Add support for image retrieval through an http proxy

--- a/client/api/rpc_enter.go
+++ b/client/api/rpc_enter.go
@@ -23,18 +23,18 @@ func (s *rpcServer) Enter(inStream pb.Kurma_EnterServer) error {
 		return err
 	}
 
-	// Create our inbound streams
-	inWriter := pb.NewByteStreamWriter(inStream, chunk.StreamId)
-	inReader := pb.NewByteStreamReader(inStream, nil)
-
-	// Create our outbound streams
-	outWriter := pb.NewByteStreamWriter(outStream, chunk.StreamId)
-	outReader := pb.NewByteStreamReader(outStream, nil)
-
 	// write the first byte to the backend so it is initialized
-	if _, err := outWriter.Write(nil); err != nil {
+	if err := outStream.Send(chunk); err != nil {
 		return err
 	}
+
+	// Create our inbound streams
+	inWriter := pb.NewByteStreamWriter(inStream, chunk.StreamId)
+	inReader := pb.NewByteStreamReader(pb.NewEnterRequestBrokerReader(inStream), nil)
+
+	// Create our outbound streams
+	outWriter := pb.NewByteStreamWriter(pb.NewEnterRequestBrokerWriter(outStream), chunk.StreamId)
+	outReader := pb.NewByteStreamReader(outStream, nil)
 
 	// stream between!
 	go io.Copy(outWriter, inReader)

--- a/stage1/client/byte_stream.go
+++ b/stage1/client/byte_stream.go
@@ -29,6 +29,37 @@ func NewByteStreamReader(stream ByteStreamReceiver, chunk *ByteChunk) io.ReadClo
 	return r
 }
 
+func NewEnterRequestBrokerReader(stream Kurma_EnterServer) ByteStreamReceiver {
+	return &enterRequestBrokerReader{stream: stream}
+}
+
+type enterRequestBrokerReader struct {
+	stream Kurma_EnterServer
+}
+
+func (r *enterRequestBrokerReader) Recv() (*ByteChunk, error) {
+	e, err := r.stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return &ByteChunk{
+		StreamId: e.StreamId,
+		Bytes:    e.Bytes,
+	}, nil
+}
+
+func NewEnterRequestBrokerWriter(stream Kurma_EnterClient) ByteStreamSender {
+	return &enterRequestBrokerWriter{stream: stream}
+}
+
+type enterRequestBrokerWriter struct {
+	stream Kurma_EnterClient
+}
+
+func (r *enterRequestBrokerWriter) Send(c *ByteChunk) error {
+	return r.stream.Send(&EnterRequest{StreamId: c.StreamId, Bytes: c.Bytes})
+}
+
 // A generic interface that is used to describe the sending end of a stream.
 type ByteStreamSender interface {
 	Send(*ByteChunk) error

--- a/stage1/client/init.pb.go
+++ b/stage1/client/init.pb.go
@@ -14,6 +14,7 @@ It has these top-level messages:
 	ContainerRequest
 	ListResponse
 	ByteChunk
+	EnterRequest
 	Container
 	None
 */
@@ -121,6 +122,16 @@ type ByteChunk struct {
 func (m *ByteChunk) Reset()         { *m = ByteChunk{} }
 func (m *ByteChunk) String() string { return proto.CompactTextString(m) }
 func (*ByteChunk) ProtoMessage()    {}
+
+type EnterRequest struct {
+	StreamId string   `protobuf:"bytes,1,opt,name=stream_id" json:"stream_id,omitempty"`
+	Command  []string `protobuf:"bytes,2,rep,name=command" json:"command,omitempty"`
+	Bytes    []byte   `protobuf:"bytes,3,opt,name=bytes,proto3" json:"bytes,omitempty"`
+}
+
+func (m *EnterRequest) Reset()         { *m = EnterRequest{} }
+func (m *EnterRequest) String() string { return proto.CompactTextString(m) }
+func (*EnterRequest) ProtoMessage()    {}
 
 type Container struct {
 	Uuid     string          `protobuf:"bytes,1,opt,name=uuid" json:"uuid,omitempty"`
@@ -246,7 +257,7 @@ func (c *kurmaClient) Enter(ctx context.Context, opts ...grpc.CallOption) (Kurma
 }
 
 type Kurma_EnterClient interface {
-	Send(*ByteChunk) error
+	Send(*EnterRequest) error
 	Recv() (*ByteChunk, error)
 	grpc.ClientStream
 }
@@ -255,7 +266,7 @@ type kurmaEnterClient struct {
 	grpc.ClientStream
 }
 
-func (x *kurmaEnterClient) Send(m *ByteChunk) error {
+func (x *kurmaEnterClient) Send(m *EnterRequest) error {
 	return x.ClientStream.SendMsg(m)
 }
 
@@ -362,7 +373,7 @@ func _Kurma_Enter_Handler(srv interface{}, stream grpc.ServerStream) error {
 
 type Kurma_EnterServer interface {
 	Send(*ByteChunk) error
-	Recv() (*ByteChunk, error)
+	Recv() (*EnterRequest, error)
 	grpc.ServerStream
 }
 
@@ -374,8 +385,8 @@ func (x *kurmaEnterServer) Send(m *ByteChunk) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func (x *kurmaEnterServer) Recv() (*ByteChunk, error) {
-	m := new(ByteChunk)
+func (x *kurmaEnterServer) Recv() (*EnterRequest, error) {
+	m := new(EnterRequest)
 	if err := x.ServerStream.RecvMsg(m); err != nil {
 		return nil, err
 	}

--- a/stage1/client/init.proto
+++ b/stage1/client/init.proto
@@ -8,7 +8,7 @@ service Kurma {
 	rpc Destroy (ContainerRequest) returns (None) {}
 	rpc List (None) returns (ListResponse) {}
 	rpc Get (ContainerRequest) returns (Container) {}
-	rpc Enter(stream ByteChunk) returns (stream ByteChunk) {}
+	rpc Enter(stream EnterRequest) returns (stream ByteChunk) {}
 }
 
 // Request/Response specific objects
@@ -34,6 +34,12 @@ message ListResponse {
 message ByteChunk {
 	string stream_id = 1;
 	bytes bytes = 2;
+}
+
+message EnterRequest {
+	string stream_id = 1;
+	repeated string command = 2;
+	bytes bytes = 3;
 }
 
 // More generic objects that are used in multiple locations.

--- a/stage1/server/rpc_enter.go
+++ b/stage1/server/rpc_enter.go
@@ -29,7 +29,7 @@ func (s *rpcServer) Enter(stream pb.Kurma_EnterServer) error {
 
 	// configure the io.Reader/Writer for the transport
 	w := pb.NewByteStreamWriter(stream, chunk.StreamId)
-	r := pb.NewByteStreamReader(stream, nil)
+	r := pb.NewByteStreamReader(pb.NewEnterRequestBrokerReader(stream), nil)
 
 	// create a pty, which we'll use for the process entering the container and
 	// copy the data back up the transport.
@@ -45,7 +45,7 @@ func (s *rpcServer) Enter(stream pb.Kurma_EnterServer) error {
 	go io.Copy(master, r)
 
 	// enter into the container
-	if err := container.Enter(slave); err != nil {
+	if err := container.Enter(chunk.Command, slave); err != nil {
 		return err
 	}
 	s.log.Debugf("Enter request finished")


### PR DESCRIPTION
This updates the "enter" API call to allow it to pass in the command that
should be executed.

Previously, the command was hard coded /bin/bash, however this was a bad
assumption as some containers may simply be busybox based and have /bin/sh.

Additionally, there are plenty of cases where the user may with to execute
something specific other than a shell, so the API has been updated to allow
the command to be provided.

If no command is provided, the base assumption has been changed to use /bin/sh.