### PR TITLE
Adds support for resource and capability isolators.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,12 +8,12 @@
 - [ ] init: Add ability for arbitruary configuration to be passed to initial
   containers.
 - [ ] stage1: Implement hook calls
-- [ ] stage1: Implement appc isolators for capabilities
-- [ ] stage1: Implement appc isolators for cgroups
 - [ ] stage1: Add resource allocation
 - [ ] stage1: Re-enable user namespace functionality
 - [ ] Review Manager/Container lock handling
 - [ ] Metadata API support
+- [X] stage1: Implement appc isolators for capabilities
+- [X] stage1: Implement appc isolators for cgroups
 - [X] stage1: Move local API to use a unix socket rather than localhost.
 - [X] stage1: Support volumes
 - [X] Look at a futex for protecting concurrent pivot_root calls.

--- a/stage1/container/container_isolators.go
+++ b/stage1/container/container_isolators.go
@@ -26,6 +26,7 @@ func (c *Container) setupLinuxNamespaceIsolator(launcher *client.Launcher) error
 			launcher.NewUserNamespace = niso.User()
 			launcher.NewUTSNamespace = niso.UTS()
 			nsisolators = true
+			c.pod.Isolators = append(c.pod.Isolators, *iso)
 		}
 	}
 	if !nsisolators {
@@ -108,6 +109,7 @@ func (c *Container) setupHostPrivilegeIsolator(launcher *client.Launcher) error 
 						})
 				}
 			}
+			c.pod.Isolators = append(c.pod.Isolators, *iso)
 		}
 	}
 
@@ -152,6 +154,7 @@ func (c *Container) setupHostApiAccessIsolator(launcher *client.Launcher) error 
 						Flags:       syscall.MS_BIND,
 					})
 			}
+			c.pod.Isolators = append(c.pod.Isolators, *iso)
 		}
 	}
 

--- a/stage1/container/utils.go
+++ b/stage1/container/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/apcera/kurma/util/capability"
 	"github.com/apcera/util/proc"
 	"github.com/appc/spec/schema/types"
 )
@@ -222,4 +223,22 @@ func convertACIdentifierToACName(name types.ACIdentifier) (*types.ACName, error)
 		return nil, err
 	}
 	return types.NewACName(n)
+}
+
+func setCap(cap *capability.Cap, acapval types.LinuxCapability, setvsclear bool) error {
+	capval, err := capability.FromName(string(acapval))
+	if err != nil {
+		return fmt.Errorf("failed to parse capability %q", acapval)
+	}
+
+	if err := cap.SetEffectiveCapability(capval, setvsclear); err != nil {
+		return fmt.Errorf("failed to set capability %q", acapval)
+	}
+	if err := cap.SetPermittedCapability(capval, setvsclear); err != nil {
+		return fmt.Errorf("failed to set capability %q", acapval)
+	}
+	if err := cap.SetInheritableCapability(capval, setvsclear); err != nil {
+		return fmt.Errorf("failed to set capability %q", acapval)
+	}
+	return nil
 }

--- a/stage2/client/client.go
+++ b/stage2/client/client.go
@@ -30,6 +30,7 @@ type Launcher struct {
 	Group         string
 	Uidmap        string
 	Gidmap        string
+	Capabilities  string
 
 	IPCNamespace     int
 	MountNamespace   int
@@ -104,6 +105,11 @@ func (l *Launcher) generateArgs(cmdargs []string) ([]string, []*os.File) {
 	}
 	if l.Group != "" {
 		args = append(args, "--group", l.Group)
+	}
+
+	// Pass capabilties, if set
+	if l.Capabilities != "" {
+		args = append(args, "--capabilities", l.Capabilities)
 	}
 
 	// Add handlers for existing namespaces

--- a/stage2/doc.go
+++ b/stage2/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2014-2015 Apcera Inc. All rights reserved.
 
-// +build linux,cgo
-
 // This spawner implementation is used to initiate the creation of a container.
 //
 // This is implemented looking like a Go binary for ease of use and reusing the
@@ -10,6 +8,7 @@
 // take over the execution and run the stage2 code.
 package stage2
 
+// #cgo linux LDFLAGS: -lcap
 import "C"
 
 import _ "github.com/apcera/kurma/stage3"

--- a/stage2/spawner.h
+++ b/stage2/spawner.h
@@ -8,6 +8,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <sys/capability.h>
 
 // This is the private structure used within the clone_* calls. This contains
 // a copy of all data used as well as the stack. This is allocated via a
@@ -82,6 +83,9 @@ typedef struct clone_destination_data {
 	// Tells the spawner to chroot into the directory.
 	bool chroot;
 
+	// The capabilities to apply to the process within the container.
+	char *capabilities;
+
 	// The UID mapping to write to the container's uid_map file
 	char *uidmap;
 
@@ -135,6 +139,7 @@ void waitforstop(pid_t child);
 void waitforexit(pid_t child);
 int uidforuser(char *user);
 int gidforgroup(char *group);
+void dropBoundingCapabilities(cap_t newcap);
 
 // -------
 // Logging

--- a/stage2/startup.c
+++ b/stage2/startup.c
@@ -101,6 +101,8 @@ void cspawner(int argc, char **argv) {
 				{"max-open-files", required_argument, 0, 'r'},
 				{"max-processes", required_argument, 0, 's'},
 
+				{"capabilities", required_argument, 0, 't'},
+
 				{"detach", no_argument, &detach, 1},
 				{"chroot", no_argument, &chroot, 1},
 				{"host-privileged", no_argument, &privileged, 1},
@@ -110,7 +112,7 @@ void cspawner(int argc, char **argv) {
 		/* getopt_long stores the option index here. */
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "abcdefghijklmnopqrs", long_options, &option_index);
+		c = getopt_long(argc, argv, "abcdefghijklmnopqrst", long_options, &option_index);
 
 		/* Detect the end of the options. */
 		if (c == -1)
@@ -204,6 +206,11 @@ void cspawner(int argc, char **argv) {
 			break;
 		case 's':
 		  args->max_processes = atoi(optarg);
+			break;
+
+			// capabilities
+		case 't':
+			args->capabilities = optarg;
 			break;
 
 		case '?':

--- a/stage3/cinitd.h
+++ b/stage3/cinitd.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include <sys/capability.h>
 #include <sys/types.h>
 
 // The maximum number of requests that can exist in the listen queue for the
@@ -301,6 +302,9 @@ int uidforuser2(char *user);
 // looking up the group in /etc/group or by converting it to an integer if it is
 // all digits.
 int gidforgroup2(char *group);
+
+// Handles configuring all the capabilities in the binding set.
+void dropBoundingCapabilities2(cap_t newcap);
 
 // -------
 // Logging

--- a/stage3/client/client.go
+++ b/stage3/client/client.go
@@ -33,7 +33,8 @@ type Client interface {
 	// Starts a given named command within the initd server.
 	Start(
 		name string, command []string, workingDirectory string, env []string,
-		stdout string, stderr, user, group string, supplementaryGids []int, timeout time.Duration,
+		stdout string, stderr, user, group string, supplementaryGids []int,
+		capabilities string, timeout time.Duration,
 	) error
 
 	// Mount will perform a mount within the container with the specified
@@ -326,7 +327,7 @@ func (c *client) Exec(
 // Issues a request to start a new command.
 func (c *client) Start(
 	name string, command []string, workingDirectory string, env []string, stdout string, stderr,
-	user, group string, supplementaryGids []int, timeout time.Duration,
+	user, group string, supplementaryGids []int, capabilities string, timeout time.Duration,
 ) error {
 	request := [][]string{
 		[]string{"START", name},
@@ -335,6 +336,8 @@ func (c *client) Start(
 		env,
 		[]string{stdout, stderr},
 		[]string{user, group},
+		[]string{},
+		[]string{capabilities},
 	}
 
 	// Convert the supplementaryGids into a string array
@@ -342,7 +345,7 @@ func (c *client) Start(
 	for i := 0; i < len(supplementaryGids); i++ {
 		suppGidsStr[i] = strconv.Itoa(supplementaryGids[i])
 	}
-	request = append(request, suppGidsStr)
+	request[6] = suppGidsStr
 
 	// Make the request.
 	response, err := c.request(request, timeout)

--- a/stage3/client/client_test.go
+++ b/stage3/client/client_test.go
@@ -213,7 +213,7 @@ func TestClient_Start(t *testing.T) {
 	client := New(socketFile)
 	err := client.Start(
 		"echo", []string{"123"}, "dir", []string{"FOO=bar"},
-		"/a", "/b", "123", "456", []int{100, 101}, time.Second,
+		"/a", "/b", "123", "456", []int{100, 101}, "foo", time.Second,
 	)
 	tt.TestExpectSuccess(t, err)
 
@@ -223,7 +223,7 @@ func TestClient_Start(t *testing.T) {
 		tt.Fatalf(t, "Expected to have read client response within 1 second")
 	}
 
-	expectedRequest := "1\n7\n2\n5\nSTART4\necho1\n3\n1231\n3\ndir1\n7\nFOO=bar2\n2\n/a2\n/b2\n3\n1233\n4562\n3\n1003\n101"
+	expectedRequest := "1\n8\n2\n5\nSTART4\necho1\n3\n1231\n3\ndir1\n7\nFOO=bar2\n2\n/a2\n/b2\n3\n1233\n4562\n3\n1003\n1011\n3\nfoo"
 	tt.TestEqual(t, startContent, expectedRequest)
 }
 

--- a/stage3/doc.go
+++ b/stage3/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2013-2015 Apcera Inc. All rights reserved.
 
-// +build linux,cgo
-
 // This implements an init binary for use as pid 1 within a container. Its
 // primary task is to launch applications within the container and to handle
 // SIGCHLD signals to reap the status for exited processes within the container.
@@ -11,4 +9,5 @@
 // requests or to check process status.
 package stage3
 
+// #cgo linux LDFLAGS: -lcap
 import "C"

--- a/stage3/start_request_test.go
+++ b/stage3/start_request_test.go
@@ -38,6 +38,7 @@ func TestUnnamedStartRequest(t *testing.T) {
 		[]string{stdout, stderr},
 		[]string{"99", "99"},
 		[]string{"100", "101"},
+		[]string{},
 	}
 	reply, err := MakeRequest(socket, request, 10*time.Second)
 	TestExpectSuccess(t, err)
@@ -90,6 +91,7 @@ func TestUnnamedStartRequest(t *testing.T) {
 		[]string{"KTEST2=VTEST2", "KTEST3=VTEST3"},
 		[]string{stdout, stderr},
 		[]string{"99", "99"},
+		[]string{},
 		[]string{},
 	}
 	reply, err = MakeRequest(socket, request, 10*time.Second)
@@ -149,6 +151,7 @@ func TestNamedStartRequest(t *testing.T) {
 		[]string{stdout, stderr},
 		[]string{"99", "99"},
 		[]string{},
+		[]string{},
 	}
 	reply, err := MakeRequest(socket, request, 10*time.Second)
 	TestExpectSuccess(t, err)
@@ -198,6 +201,7 @@ func TestNamedStartRequest(t *testing.T) {
 		[]string{stdout, stderr},
 		[]string{"99", "99"},
 		[]string{},
+		[]string{},
 	}
 	reply, err = MakeRequest(socket, request, 10*time.Second)
 	TestExpectSuccess(t, err)
@@ -245,6 +249,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"ENVKEY=ENVVALUE"},
 			[]string{"STDOUT", "STDERR"},
 			[]string{},
+			[]string{},
 		},
 
 		// Test 2: Request is too long..
@@ -255,6 +260,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"ENVKEY=ENVVALUE"},
 			[]string{"STDOUT", "STDERR"},
 			[]string{"UID", "GID"},
+			[]string{},
 			[]string{},
 			[]string{},
 		},
@@ -268,6 +274,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"STDOUT", "STDERR"},
 			[]string{"UID", "GID"},
 			[]string{},
+			[]string{},
 		},
 
 		// Test 4: Extra cruft after STDERR
@@ -278,6 +285,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"ENVKEY=ENVVALUE"},
 			[]string{"STDOUT", "STDERR", "EXTRA"},
 			[]string{"UID", "GID"},
+			[]string{},
 			[]string{},
 		},
 
@@ -290,6 +298,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"STDOUT", "STDERR"},
 			[]string{"UID", "GID", "EXTRA"},
 			[]string{},
+			[]string{},
 		},
 
 		// Test 6: Missing COMMAND
@@ -300,6 +309,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"ENVKEY=ENVVALUE"},
 			[]string{"STDOUT", "STDERR"},
 			[]string{"UID", "GID"},
+			[]string{},
 			[]string{},
 		},
 
@@ -312,6 +322,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"STDOUT", "STDERR"},
 			[]string{"UID", "GID"},
 			[]string{},
+			[]string{},
 		},
 
 		// Test 8: Missing STDERR
@@ -322,6 +333,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"ENVKEY=ENVVALUE"},
 			[]string{"STDOUT"},
 			[]string{"UID", "GID"},
+			[]string{},
 			[]string{},
 		},
 
@@ -334,6 +346,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{},
 			[]string{"UID", "GID"},
 			[]string{},
+			[]string{},
 		},
 
 		// Test 10: Missing GID
@@ -345,6 +358,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"STDOUT", "STDERR"},
 			[]string{"UID"},
 			[]string{},
+			[]string{},
 		},
 
 		// Test 11: Missing UID
@@ -354,6 +368,7 @@ func TestBadStartRequest(t *testing.T) {
 			[]string{"DIR"},
 			[]string{"ENVKEY=ENVVALUE"},
 			[]string{"STDOUT", "STDERR"},
+			[]string{},
 			[]string{},
 			[]string{},
 		},

--- a/stage3/status_request_test.go
+++ b/stage3/status_request_test.go
@@ -47,6 +47,7 @@ func TestStatusRequest(t *testing.T) {
 			[]string{stdout, stderr},
 			[]string{"99", "99"},
 			[]string{},
+			[]string{},
 		}
 		reply, err := MakeRequest(socket, request, 10*time.Second)
 		TestExpectSuccess(t, err)

--- a/stage3/wait_request_test.go
+++ b/stage3/wait_request_test.go
@@ -39,6 +39,7 @@ func TestWaitRequest(t *testing.T) {
 		[]string{stdout, stderr},
 		[]string{"99", "99"},
 		[]string{},
+		[]string{},
 	}
 	reply, err := MakeRequest(socket, request, 10*time.Second)
 	TestExpectSuccess(t, err)
@@ -122,6 +123,7 @@ func TestWaitRequestDoesntBlockProcessesAreFinished(t *testing.T) {
 		[]string{"KTEST=VTEST"},
 		[]string{stdout, stderr},
 		[]string{"99", "99"},
+		[]string{},
 		[]string{},
 	}
 	reply, err := MakeRequest(socket, request, 10*time.Second)

--- a/util/capability/cap.go
+++ b/util/capability/cap.go
@@ -1,0 +1,451 @@
+// Copyright 2013-2015 Apcera Inc. All rights reserved.
+
+// +build linux,cgo
+
+package capability
+
+// #cgo linux LDFLAGS: -lcap
+// #include <sys/capability.h>
+// #include <stdlib.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type CapValue int
+
+// FromName will parse the given text and return the corresponding CapValue, or
+// error if it fails to parse it.
+func FromName(name string) (CapValue, error) {
+	return cap_from_name(name)
+}
+
+const (
+	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
+	// overrides the restriction of changing file ownership and group
+	// ownership.
+	CAP_CHOWN = CapValue(int(iota))
+
+	// Override all DAC access, including ACL execute access if
+	// [_POSIX_ACL] is defined. Excluding DAC access covered by
+	// CAP_LINUX_IMMUTABLE.
+	CAP_DAC_OVERRIDE
+
+	// Overrides all DAC restrictions regarding read and search on files
+	// and directories, including ACL restrictions if [_POSIX_ACL] is
+	// defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE.
+	CAP_DAC_READ_SEARCH
+
+	// Overrides all restrictions about allowed operations on files, where
+	// file owner ID must be equal to the user ID, except where CAP_FSETID
+	// is applicable. It doesn't override MAC and DAC restrictions.
+	CAP_FOWNER
+
+	// Overrides the following restrictions that the effective user ID
+	// shall match the file owner ID when setting the S_ISUID and S_ISGID
+	// bits on that file; that the effective group ID (or one of the
+	// supplementary group IDs) shall match the file owner ID when setting
+	// the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	// cleared on successful return from chown(2) (not implemented).
+	CAP_FSETID
+
+	// Overrides the restriction that the real or effective user ID of a
+	// process sending a signal must match the real or effective user ID
+	// of the process receiving the signal.
+	CAP_KILL
+
+	// * Allows setgid(2) manipulation
+	// * Allows setgroups(2)
+	// * Allows forged gids on socket credentials passing.
+	CAP_SETGID
+
+	// * Allows set*uid(2) manipulation (including fsuid).
+	// * Allows forged pids on socket credentials passing.
+	CAP_SETUID
+
+	// Linux-specific capabilities
+
+	// Without VFS support for capabilities:
+	// * Transfer any capability in your permitted set to any pid,
+	// * remove any capability in your permitted set from any pid
+	//
+	// With VFS support for capabilities (neither of above, but)
+	// *   Add any capability from current's capability bounding set
+	// *       to the current process' inheritable set
+	// *   Allow taking bits out of capability bounding set
+	// *   Allow modification of the securebits for a process
+	CAP_SETPCAP
+
+	// * Allow modification of S_IMMUTABLE and S_APPEND file attributes
+	CAP_LINUX_IMMUTABLE
+
+	// * Allows binding to TCP/UDP sockets below 1024
+	// * Allows binding to ATM VCIs below 32
+	CAP_NET_BIND_SERVICE
+
+	// * Allow broadcasting, listen to multicast
+	CAP_NET_BROADCAST
+
+	// * Allow interface configuration
+	// * Allow administration of IP firewall, masquerading and accounting
+	// * Allow setting debug option on sockets
+	// * Allow modification of routing tables
+	// * Allow setting arbitrary process / process group ownership on sockets
+	// * Allow binding to any address for transparent proxying
+	//   (also via NET_RAW)
+	// * Allow setting TOS (type of service)
+	// * Allow setting promiscuous mode
+	// * Allow clearing driver statistics
+	// * Allow multicasting
+	// * Allow read/write of device-specific registers
+	// * Allow activation of ATM control sockets
+	CAP_NET_ADMIN
+
+	// * Allow use of RAW sockets
+	// * Allow use of PACKET sockets
+	// * Allow binding to any address for transparent proxying
+	//   (also via NET_ADMIN)
+	CAP_NET_RAW
+
+	// * Allow blocking of shared memory segments
+	// * Allow mlock and mlockall (which doesn't really have anything to do
+	//   with IPC)
+	CAP_IPC_LOCK
+
+	// * Override IPC ownership checks
+	CAP_IPC_OWNER
+
+	// * Insert and remove kernel modules - modify kernel without limit
+	CAP_SYS_MODULE
+
+	// * Allow ioperm/iopl access
+	// * Allow sending USB messages to any device via /proc/bus/usb
+	CAP_SYS_RAWIO
+
+	// * Allow use of chroot()
+	CAP_SYS_CHROOT
+
+	// * Allow ptrace() of any process
+	CAP_SYS_PTRACE
+
+	// * Allow configuration of process accounting
+	CAP_SYS_PACCT
+
+	// * Allow configuration of the secure attention key
+	// * Allow administration of the random device
+	// * Allow examination and configuration of disk quotas
+	// * Allow setting the domainname
+	// * Allow setting the hostname
+	// * Allow calling bdflush()
+	// * Allow mount() and umount(), setting up new smb connection
+	// * Allow some autofs root ioctls
+	// * Allow nfsservctl
+	// * Allow VM86_REQUEST_IRQ
+	// * Allow to read/write pci config on alpha
+	// * Allow irix_prctl on mips (setstacksize)
+	// * Allow flushing all cache on m68k (sys_cacheflush)
+	// * Allow removing semaphores
+	// * Used instead of CAP_CHOWN to "chown" IPC message queues, semaphores
+	//   and shared memory
+	// * Allow locking/unlocking of shared memory segment
+	// * Allow turning swap on/off
+	// * Allow forged pids on socket credentials passing
+	// * Allow setting readahead and flushing buffers on block devices
+	// * Allow setting geometry in floppy driver
+	// * Allow turning DMA on/off in xd driver
+	// * Allow administration of md devices (mostly the above, but some
+	//   extra ioctls)
+	// * Allow tuning the ide driver
+	// * Allow access to the nvram device
+	// * Allow administration of apm_bios, serial and bttv (TV) device
+	// * Allow manufacturer commands in isdn CAPI support driver
+	// * Allow reading non-standardized portions of pci configuration space
+	// * Allow DDI debug ioctl on sbpcd driver
+	// * Allow setting up serial ports
+	// * Allow sending raw qic-117 commands
+	// * Allow enabling/disabling tagged queuing on SCSI controllers and sending
+	//   arbitrary SCSI commands
+	// * Allow setting encryption key on loopback filesystem
+	// * Allow setting zone reclaim policy
+	CAP_SYS_ADMIN
+
+	// * Allow use of reboot()
+	CAP_SYS_BOOT
+
+	// * Allow raising priority and setting priority on other (different
+	//   UID) processes
+	// * Allow use of FIFO and round-robin (realtime) scheduling on own
+	//   processes and setting the scheduling algorithm used by another
+	//   process.
+	// * Allow setting cpu affinity on other processes
+
+	CAP_SYS_NICE
+
+	// * Override resource limits. Set resource limits.
+	// * Override quota limits.
+	// * Override reserved space on ext2 filesystem
+	// * Modify data journaling mode on ext3 filesystem (uses journaling
+	// * resources)
+	// * NOTE: ext2 honors fsuid when checking for resource overrides, so
+	// * you can override using fsuid too
+	// * Override size restrictions on IPC message queues
+	// * Allow more than 64hz interrupts from the real-time clock
+	// * Override max number of consoles on console allocation
+	// * Override max number of keymaps
+	CAP_SYS_RESOURCE
+
+	// * Allow manipulation of system clock
+	// * Allow irix_stime on mips
+	// * Allow setting the real-time clock
+	CAP_SYS_TIME
+
+	// * Allow configuration of tty devices
+	// * Allow vhangup() of tty
+	CAP_SYS_TTY_CONFIG
+
+	// * Allow the privileged aspects of mknod()
+	CAP_MKNOD
+
+	// * Allow taking of leases on files
+	CAP_LEASE
+
+	CAP_AUDIT_WRITE
+
+	CAP_AUDIT_CONTROL
+
+	CAP_SETFCAP
+
+	// Override MAC access.
+	// The base kernel enforces no MAC policy.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based overrides of that policy, this is
+	// the capability it should use to do so.
+	CAP_MAC_OVERRIDE
+
+	// Allow MAC configuration or state changes.
+	// The base kernel requires no MAC configuration.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based checks on modifications to that
+	// policy or the data required to maintain it, this is the
+	// capability it should use to do so.
+	CAP_MAC_ADMIN
+
+	// * Allow configuring the kernel's syslog (printk behaviour)
+	CAP_SYSLOG
+
+	// This is the marker for the last capability in the list
+	CAP_LAST
+)
+
+// Returns the cap_t type for the given flag.
+func (f CapValue) capT() C.cap_value_t {
+	switch f {
+	case CAP_CHOWN:
+		return C.CAP_CHOWN
+	case CAP_DAC_OVERRIDE:
+		return C.CAP_DAC_OVERRIDE
+	case CAP_DAC_READ_SEARCH:
+		return C.CAP_DAC_READ_SEARCH
+	case CAP_FOWNER:
+		return C.CAP_FOWNER
+	case CAP_FSETID:
+		return C.CAP_FSETID
+	case CAP_KILL:
+		return C.CAP_KILL
+	case CAP_SETGID:
+		return C.CAP_SETGID
+	case CAP_SETUID:
+		return C.CAP_SETUID
+	case CAP_SETPCAP:
+		return C.CAP_SETPCAP
+	case CAP_LINUX_IMMUTABLE:
+		return C.CAP_LINUX_IMMUTABLE
+	case CAP_NET_BIND_SERVICE:
+		return C.CAP_NET_BIND_SERVICE
+	case CAP_NET_BROADCAST:
+		return C.CAP_NET_BROADCAST
+	case CAP_NET_ADMIN:
+		return C.CAP_NET_ADMIN
+	case CAP_NET_RAW:
+		return C.CAP_NET_RAW
+	case CAP_IPC_LOCK:
+		return C.CAP_IPC_LOCK
+	case CAP_IPC_OWNER:
+		return C.CAP_IPC_OWNER
+	case CAP_SYS_MODULE:
+		return C.CAP_SYS_MODULE
+	case CAP_SYS_RAWIO:
+		return C.CAP_SYS_RAWIO
+	case CAP_SYS_CHROOT:
+		return C.CAP_SYS_CHROOT
+	case CAP_SYS_PTRACE:
+		return C.CAP_SYS_PTRACE
+	case CAP_SYS_PACCT:
+		return C.CAP_SYS_PACCT
+	case CAP_SYS_ADMIN:
+		return C.CAP_SYS_ADMIN
+	case CAP_SYS_BOOT:
+		return C.CAP_SYS_BOOT
+	case CAP_SYS_NICE:
+		return C.CAP_SYS_NICE
+	case CAP_SYS_RESOURCE:
+		return C.CAP_SYS_RESOURCE
+	case CAP_SYS_TIME:
+		return C.CAP_SYS_TIME
+	case CAP_SYS_TTY_CONFIG:
+		return C.CAP_SYS_TTY_CONFIG
+	case CAP_MKNOD:
+		return C.CAP_MKNOD
+	case CAP_LEASE:
+		return C.CAP_LEASE
+	case CAP_AUDIT_WRITE:
+		return C.CAP_AUDIT_WRITE
+	case CAP_AUDIT_CONTROL:
+		return C.CAP_AUDIT_CONTROL
+	case CAP_SETFCAP:
+		return C.CAP_SETFCAP
+	case CAP_MAC_OVERRIDE:
+		return C.CAP_MAC_OVERRIDE
+	case CAP_MAC_ADMIN:
+		return C.CAP_MAC_ADMIN
+	case CAP_SYSLOG:
+		return C.CAP_SYSLOG
+		//	case CAP_WAKE_ALARM:
+		//		return C.CAP_WAKE_ALARM
+		//	case CAP_BLOCK_SUSPEND:
+		//		return C.CAP_BLOCK_SUSPEND
+	}
+	panic("UNKNOWN CAPABILITY TYPE")
+}
+
+type Cap struct {
+	data C.cap_t
+}
+
+// isset returns whether the specified capabilities is in the given capability
+// set.
+func (cap *Cap) isset(value CapValue, flag C.cap_flag_t) (bool, error) {
+	var dest C.cap_flag_value_t
+	n, err := C.cap_get_flag(cap.data, value.capT(), flag, &dest)
+	if err != nil {
+		return false, err
+	}
+
+	if n != 0 {
+		return false, fmt.Errorf("Unknown error returned from cap_get_flag: %d", n)
+	}
+
+	if dest == C.CAP_SET {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (cap *Cap) set(value CapValue, flag C.cap_flag_t, set C.cap_flag_value_t) error {
+	cap_value := value.capT()
+	ret := C.cap_set_flag(cap.data, flag, 1, &cap_value, set)
+	if ret != 0 {
+		return fmt.Errorf("failed to set the desired value")
+	}
+	return nil
+}
+
+// EffectiveCapability returns true if the given capability (value) in its
+// effective set of capabilities. This means that the process is actively being
+// allowed the permissions that the capability grants.
+func (cap *Cap) EffectiveCapability(flag CapValue) (bool, error) {
+	return cap.isset(flag, C.CAP_EFFECTIVE)
+}
+
+// PermittedCapabilityr eturns true if the given capability (value) in its
+// permitted set of capabilities.
+func (cap *Cap) PermittedCapability(flag CapValue) (bool, error) {
+	return cap.isset(flag, C.CAP_PERMITTED)
+}
+
+// InheritableCapability returns true if the given capability (value) in its
+// permitted set of capabilities.
+func (cap *Cap) InheritableCapability(flag CapValue) (bool, error) {
+	return cap.isset(flag, C.CAP_INHERITABLE)
+}
+
+// SetEffectiveCapability will enable the specified capability in the effective
+// set.
+func (cap *Cap) SetEffectiveCapability(flag CapValue, set bool) error {
+	if set {
+		return cap.set(flag, C.CAP_EFFECTIVE, C.CAP_SET)
+	}
+	return cap.set(flag, C.CAP_EFFECTIVE, C.CAP_CLEAR)
+}
+
+// SetPermittedCapability will enable the specified capability in the permitted
+// set.
+func (cap *Cap) SetPermittedCapability(flag CapValue, set bool) error {
+	if set {
+		return cap.set(flag, C.CAP_PERMITTED, C.CAP_SET)
+	}
+	return cap.set(flag, C.CAP_PERMITTED, C.CAP_CLEAR)
+}
+
+// SetInheritableCapability will enable the specified capability in the
+// inheritable set.
+func (cap *Cap) SetInheritableCapability(flag CapValue, set bool) error {
+	if set {
+		return cap.set(flag, C.CAP_INHERITABLE, C.CAP_SET)
+	}
+	return cap.set(flag, C.CAP_INHERITABLE, C.CAP_CLEAR)
+}
+
+// Free will release the current capability object, releasing the memory.
+func (cap *Cap) Free() {
+	C.cap_free(unsafe.Pointer(cap.data))
+}
+
+// Clear will reset all capabilities.
+func (cap *Cap) Clear() {
+	C.cap_clear(cap.data)
+}
+
+// String will convert the current capabilities set into a string representation
+// using cap_to_text().
+func (cap *Cap) String() string {
+	s, _ := cap_to_text(cap)
+	return s
+}
+
+// NewFromPid will return a new capabilities set for the process specified by
+// pid.
+func NewFromPid(pid int) (*Cap, error) {
+	return cap_get_pid(pid)
+}
+
+func cap_get_pid(pid int) (*Cap, error) {
+	cap_t, err := C.cap_get_pid(C.pid_t(pid))
+	if err != nil {
+		return nil, err
+	}
+	return &Cap{data: cap_t}, nil
+}
+
+func cap_to_text(cap *Cap) (string, error) {
+	cString := C.cap_to_text(cap.data, nil)
+	if cString == nil {
+		return "", fmt.Errorf("failed to convert capabilities to text")
+	}
+	defer C.cap_free(unsafe.Pointer(cString))
+	return C.GoString(cString), nil
+}
+
+func cap_from_name(name string) (CapValue, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var capv C.cap_value_t
+	ret := C.cap_from_name(cname, &capv)
+	if ret != 0 {
+		return CapValue(0), fmt.Errorf("failed to parse the capability name")
+	}
+	return CapValue(int(capv)), nil
+}

--- a/util/capability/cap_test.go
+++ b/util/capability/cap_test.go
@@ -1,0 +1,159 @@
+// Copyright 2013-2015 Apcera Inc. All rights reserved.
+
+// +build linux,cgo
+
+package capability
+
+import (
+	"os"
+	"testing"
+
+	tt "github.com/apcera/util/testtool"
+)
+
+func TestCapValue(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	for i := 0; i < int(CAP_LAST); i++ {
+		CapValue(i).capT()
+	}
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatalf("Panic not called.")
+		}
+	}()
+	CapValue(CAP_LAST).capT()
+}
+
+func TestCapValueFromName(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	capv, err := FromName("CAP_KILL")
+	tt.TestExpectSuccess(t, err)
+
+	tt.TestEqual(t, capv, CAP_KILL)
+}
+
+func TestEffectiveCapability(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	cap, err := NewFromPid(os.Getpid())
+	tt.TestExpectSuccess(t, err)
+
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatalf("Panic not called.")
+		}
+	}()
+	for i := 0; i <= int(CAP_LAST); i++ {
+		c := CapValue(i)
+		if _, err := cap.EffectiveCapability(c); err != nil {
+			t.Fatalf("Error returned %d: %s", i, err)
+		}
+	}
+}
+
+func TestPermittedCapability(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	cap, err := NewFromPid(os.Getpid())
+	tt.TestExpectSuccess(t, err)
+
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatalf("Panic not called.")
+		}
+	}()
+	for i := 0; i <= int(CAP_LAST); i++ {
+		c := CapValue(i)
+		if _, err := cap.PermittedCapability(c); err != nil {
+			t.Fatalf("Error returned %d: %s", i, err)
+		}
+	}
+}
+
+func TestInheritableCapability(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	cap, err := NewFromPid(os.Getpid())
+	tt.TestExpectSuccess(t, err)
+
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatalf("Panic not called.")
+		}
+	}()
+	for i := 0; i <= int(CAP_LAST); i++ {
+		c := CapValue(i)
+		if _, err := cap.InheritableCapability(c); err != nil {
+			t.Fatalf("Error returned %d: %s", i, err)
+		}
+	}
+}
+
+func TestSetFunctions(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	cap, err := NewFromPid(os.Getpid())
+	tt.TestExpectSuccess(t, err)
+
+	cap.Clear()
+
+	val, err := cap.EffectiveCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, false)
+
+	val, err = cap.InheritableCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, false)
+
+	val, err = cap.PermittedCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, false)
+
+	tt.TestExpectSuccess(t, cap.SetEffectiveCapability(CAP_KILL, true))
+	tt.TestExpectSuccess(t, cap.SetInheritableCapability(CAP_KILL, true))
+	tt.TestExpectSuccess(t, cap.SetPermittedCapability(CAP_KILL, true))
+
+	val, err = cap.EffectiveCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, true)
+
+	val, err = cap.InheritableCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, true)
+
+	val, err = cap.PermittedCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, true)
+}
+
+func TestCapStringConverstion(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	cap, err := NewFromPid(os.Getpid())
+	tt.TestExpectSuccess(t, err)
+
+	cap.Clear()
+
+	val, err := cap.EffectiveCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, false)
+
+	err = cap.SetEffectiveCapability(CAP_KILL, true)
+	tt.TestExpectSuccess(t, err)
+
+	val, err = cap.EffectiveCapability(CAP_KILL)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, val, true)
+
+	str := cap.String()
+	tt.TestEqual(t, str, "= cap_kill+e")
+}


### PR DESCRIPTION
This adds support for the CPU and memory resource isolators through
cgroups.

This also adds support for Linux capabilities isolators, to either
specify the retained or the revoked set of capabilities. Capabilities
will be applied within the stage3 process on START requests. It won't
apply it to the stage3 process itself, as the scoped capabilities may
prevent it from the starting the application.

This also adds support for capabilities to the stage2 process. This is
used with the enter command, and ensures entering the container
preserves the intended capabilities.