### PR TITLE
stager: Restructured the container stager to a single executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,10 @@ bin/kurma-init.tar.gz: kurma-init bin/stager-container.aci bin/console.aci bin/n
 # Stager - Container
 #
 bin/stager-container-main: *
-	$(DOCKER) go build -o ${BASEPATH}/$@ stager/container.go
+	$(DOCKER) go build -o ${BASEPATH}/$@ stager/container/main.go
 bin/stager-container-init: stager/container/init/init.c
 	$(DOCKER) gcc -static -o ${BASEPATH}/$@ stager/container/init/init.c
-bin/stager-container-run: *
-	$(DOCKER) go build -o ${BASEPATH}/$@ stager/container/cmd/run/main.go
-bin/stager-container.aci: bin/stager-container-main bin/stager-container-init bin/stager-container-run
+bin/stager-container.aci: bin/stager-container-main bin/stager-container-init
 	$(DOCKER) ./build/aci/kurma-stager-container/build.sh $@
 .PHONY: stager/container
 stager/container: bin/stager-container.aci

--- a/build/aci/kurma-stager-container/build.sh
+++ b/build/aci/kurma-stager-container/build.sh
@@ -22,9 +22,9 @@ cp ../../../bin/stager-container-main $dir/stager
 mkdir $dir/init
 cp ../../../bin/stager-container-init $dir/init/init
 
-# other stager entry points
+# symlink other stager entry points
 mkdir -p $dir/opt/stager
-cp ../../../bin/stager-container-run $dir/opt/stager/run
+ln -s /stager $dir/opt/stager/run
 
 # copy some other binaries that may be needed
 mkdir $dir/bin

--- a/stager/container/common/types.go
+++ b/stager/container/common/types.go
@@ -1,27 +1,27 @@
 // Copyright 2016 Apcera Inc. All rights reserved.
 
-package container
+package common
 
-type stagerRuntimeState string
+type StagerRuntimeState string
 
 const (
-	stagerStateSetup    = stagerRuntimeState("setup")
-	stagerStateRunning  = stagerRuntimeState("running")
-	stagerStateTeardown = stagerRuntimeState("teardown")
+	StagerStateSetup    = StagerRuntimeState("setup")
+	StagerStateRunning  = StagerRuntimeState("running")
+	StagerStateTeardown = StagerRuntimeState("teardown")
 )
 
-type stagerConfig struct {
+type StagerConfig struct {
 	RequiredNamespaces []string `json:"requiredNamespaces"`
 	DefaultNamespaces  []string `json:"defaultNamespaces"`
 	GraphStorage       string   `json:"graphStorage"`
 }
 
-type stagerState struct {
-	Apps  map[string]*stagerAppState `json:"apps"`
-	State stagerRuntimeState         `json:"state"`
+type StagerState struct {
+	Apps  map[string]*StagerAppState `json:"apps"`
+	State StagerRuntimeState         `json:"state"`
 }
 
-type stagerAppState struct {
+type StagerAppState struct {
 	Pid        int    `json:"pid,omitempty"`
 	Exited     bool   `json:"exited"`
 	ExitCode   int    `json:"exitCode,omitempty"`

--- a/stager/container/core/core.go
+++ b/stager/container/core/core.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package core
+
+import (
+	"runtime"
+
+	"github.com/apcera/logray"
+	"github.com/opencontainers/runc/libcontainer"
+)
+
+func Run() error {
+	logray.AddDefaultOutput("stdout://", logray.ALL)
+	cs := &containerSetup{
+		log:           logray.New(),
+		stagerConfig:  defaultStagerConfig,
+		appContainers: make(map[string]libcontainer.Container),
+		appProcesses:  make(map[string]*libcontainer.Process),
+		appWaitch:     make(map[string]chan struct{}),
+	}
+	if err := cs.run(); err != nil {
+		return err
+	}
+	runtime.Goexit()
+	return nil
+}

--- a/stager/container/core/isolators.go
+++ b/stager/container/core/isolators.go
@@ -1,6 +1,6 @@
 // Copyright 2016 Apcera Inc. All rights reserved.
 
-package container
+package core
 
 import (
 	"fmt"

--- a/stager/container/core/util.go
+++ b/stager/container/core/util.go
@@ -1,6 +1,6 @@
 // Copyright 2016 Apcera Inc. All rights reserved.
 
-package container
+package core
 
 import (
 	"fmt"
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/apcera/kurma/stager/container/common"
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
 	"github.com/opencontainers/runc/libcontainer"
@@ -192,7 +193,7 @@ func (cs *containerSetup) getPodApp(runtimeApp schema.RuntimeApp) *types.App {
 func (cs *containerSetup) isShuttingDown() bool {
 	cs.stateMutex.Lock()
 	defer cs.stateMutex.Unlock()
-	return cs.state.State == stagerStateTeardown
+	return cs.state.State == common.StagerStateTeardown
 }
 
 // getNamespaceIsolator checks the pod manifest to see is a linux namespace

--- a/stager/container/run/run.go
+++ b/stager/container/run/run.go
@@ -1,49 +1,33 @@
 // Copyright 2016 Apcera Inc. All rights reserved.
 
-package main
+package run
 
 import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/appc/spec/schema/types"
 	"github.com/opencontainers/runc/libcontainer"
-
-	_ "github.com/opencontainers/runc/libcontainer/nsenter"
 )
 
-func init() {
-	runtime.GOMAXPROCS(1)
-	runtime.LockOSThread()
-
-	if len(os.Args) > 1 && os.Args[1] == "init" {
-		factory, _ := libcontainer.New("")
-		if err := factory.StartInitialization(); err != nil {
-			panic(err)
-		}
-		panic("--this line should have never been executed, congratulations--")
-	}
-}
-
-func main() {
+func Run() error {
 	var app *types.App
 
 	f := os.NewFile(3, "app.json")
 	if err := json.NewDecoder(f).Decode(&app); err != nil {
-		panic(err)
+		return err
 	}
 	f.Close()
 
 	factory, err := libcontainer.New("/containers")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	container, err := factory.Load(os.Args[1])
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	workingDirectory := app.WorkingDirectory
@@ -63,7 +47,8 @@ func main() {
 		process.Env = append(process.Env, fmt.Sprintf("%s=%s", env.Name, env.Value))
 	}
 	if err := container.Start(process); err != nil {
-		panic(err)
+		return err
 	}
 	process.Wait()
+	return nil
 }


### PR DESCRIPTION
Restructured the container stager to focus on each of the call in points
being a package and a single executable main function.

With this, each package will be able to test individually rather than
multiple main() functions everywhere.

Additionally, with a single executable that switches off of os.Args[0],
the size of the stager's ACI image is reduced by about 35%.

FYI PR