### PR TITLE
kurmad: Add support for signal handling to do clean shutdown

### DIFF
--- a/kurmad/kurmad.go
+++ b/kurmad/kurmad.go
@@ -20,6 +20,7 @@ var (
 	// The setup functions that should be run in order to handle setting up
 	// kurmad.
 	setupFunctions = []func(*runner) error{
+		(*runner).setupSignalHandling,
 		(*runner).loadConfigurationFile,
 		(*runner).configureLogging,
 		(*runner).createDirectories,

--- a/pkg/backend/interfaces.go
+++ b/pkg/backend/interfaces.go
@@ -123,6 +123,10 @@ type PodManager interface {
 	// operation. This is a temporary hack util a Pod object can specify its own
 	// path.
 	SwapDirectory(podDirectory string, f func())
+
+	// Shutdown requests that the pod manager shut down running pods to prepare to
+	// exit.
+	Shutdown()
 }
 
 // PodOptions is a set of locally available options to extend instrumentation

--- a/testing/integration/lib/kurma/server.rb
+++ b/testing/integration/lib/kurma/server.rb
@@ -59,7 +59,6 @@ podNetworks:
     @pid = fork do
       logfile = File.open(self.kurma_logfile, "a")
       Dir.chdir(@tmpdir) do
-        %w( pods images volumes ).each { |d| Dir.mkdir(d) }
         $stdin.reopen("/dev/null")
         $stdout.reopen(logfile)
         $stderr.reopen(logfile)
@@ -74,7 +73,7 @@ podNetworks:
 
   def stop
     if File.exists?("/proc/#{@pid}")
-      %x{sudo kill -QUIT $(sudo cat /proc/#{@pid}/task/#{@pid}/children)}
+      %x{sudo kill -TERM $(sudo cat /proc/#{@pid}/task/#{@pid}/children)}
       begin
         wait_for_exit
       rescue Kurma::Error


### PR DESCRIPTION
This adds signal handling for SIGTERM, SIGINT, and SIGQUIT to perform a
graceful shutdown, including tearing down all of the running pods.

In the future, plan on instrumenting restarting without tearing down
pods (likely with a SIGUSR1) and reloading configuration (likely
SIGHUP).

This adds a Shutdown method to the PodManager interface. The
implementation makes sure to leave the networking pod for last, so that
all other pods will be able to have their networking deprovisioned
properly.

Also changed the integration tests to use SIGTERM rather than
SIGQUIT. It generally is a better fit.

FYI PR