### PR TITLE
Updates for developer documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,4 +162,4 @@ test: ## Locally run the unit tests
 #
 .PHONY: help
 help:
-	@grep -E '^[a-zA-Z_-/]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_/\\-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for augmenting a developer workflow, such as
 [Docker Toolbox](https://www.docker.com/products/docker-toolbox). We leverage
 that rather than reinventing.
 
-To develop and build against Kurma, all will need the following:
+To develop and build against Kurma, all you will need is the following:
 
 * Docker (if not on Linux, we recommend using [Docker Toolbox](https://www.docker.com/products/docker-toolbox))
 * Go 1.6
@@ -41,7 +41,7 @@ For a list of some of the most common tasks, you can run `make help` to see a
 list and description of some of the tasks.
 
 For local development, you should check out the `kurma` repository within your
-`$GOPATH` so that it is at `$GOPATH/src/github.com/lkurma`. You'll typically
+`$GOPATH` so that it is at `$GOPATH/src/github.com/kurma`. You'll typically
 need to run `make download` to fetch some of the pre-compiled assets (busybox
 image, CNI networking image), then run `make local` to compile local binaries
 and `make run` to run the daemon mode. If on OS X, this will start the daemon in

--- a/README.md
+++ b/README.md
@@ -18,9 +18,53 @@ and see our [documentation](https://kurma.io/documentation).
 
 ### Building Kurma
 
-See the
-[KurmaOS Repo](https://github.com/apcera/kurmaos/blob/master/README.md#build-process)
-for instructions on how to build Kurma.
+Building Kurma is made possible by leveraging Docker. You may say "your
+container engine is built with another container?" Yep. Docker has great tooling
+for augmenting a developer workflow, such as
+[Docker Toolbox](https://www.docker.com/products/docker-toolbox). We leverage
+that rather than reinventing.
+
+To develop and build against Kurma, all will need the following:
+
+* Docker (if not on Linux, we recommend using [Docker Toolbox](https://www.docker.com/products/docker-toolbox))
+* Go 1.6
+
+Most compilation is done through Docker to ensure all compiling is done through
+our pre-built build environment images. This allows you to easily build Kurma on
+Linux even if you're running OS X. The CLI is still natively compiled, so if
+you're on OS X, you get a CLI built for OS X.
+
+Our `Makefile` will automatically ensure you're running within Docker and map in
+the code at the necessary location, set the GOPATH, and ensure users match.
+
+For a list of some of the most common tasks, you can run `make help` to see a
+list and description of some of the tasks.
+
+For local development, you should check out the `kurma` repository within your
+`$GOPATH` so that it is at `$GOPATH/src/github.com/lkurma`. You'll typically
+need to run `make download` to fetch some of the pre-compiled assets (busybox
+image, CNI networking image), then run `make local` to compile local binaries
+and `make run` to run the daemon mode. If on OS X, this will start the daemon in
+Docker and print out how to connect. To shut down the server, simply press
+Control-C and it will tear down all pods and exit.
+
+```shell
+$ git clone git@github.com:apcera/kurma.git $GOPATH/src/github.com/apcera/kurma
+$ cd $GOPATH/src/github.com/apcera/kurma
+$ make download
+...
+$ make local
+...
+$ make run
+Running kurmad
+==============================================================
+Kurma remote API will be available at 172.17.0.2:12312
+
+To connect with kurma-cli, please run:
+  export KURMA_HOST=172.17.0.2
+==============================================================
+...
+```
 
 ### Downloading Kurma
 

--- a/build/aci/kurma-api/manifest.yaml
+++ b/build/aci/kurma-api/manifest.yaml
@@ -3,12 +3,8 @@ name: apcera.com/kurma/api
 app:
   exec:
   - /kurma-api
-  user: "1000"
-  group: "1000"
+  user: "0"
+  group: "0"
   isolators:
   - name: host/api-access
     value: true
-  - name: os/linux/namespaces
-    value:
-      net: host
-      uts: host

--- a/build/local-kurmad.yml
+++ b/build/local-kurmad.yml
@@ -1,0 +1,46 @@
+---
+
+##
+## Example kurmad configuration file for local development
+##
+
+# Note the paths here are intentional, as the running of the daemon is setup
+# through `run.sh`
+
+socketPath: ./kurma.sock
+socketPermissions: 0666
+parentCgroupName: kurma
+podsDirectory: ./pods
+imagesDirectory: ./images
+volumesDirectory: ./volumes
+defaultStagerImage: file://source/bin/stager-container.aci
+
+prefetchImages:
+- file://source/bin/busybox.aci
+- file://source/bin/kurma-api.aci
+
+initialPods:
+- name: api-proxy
+  apps:
+  - name: api-proxy
+    image:
+      name: apcera.com/kurma/api
+  isolators:
+  - name: os/linux/namespaces
+    value:
+      net: host
+      uts: host
+
+podNetworks:
+- name: bridge
+  aci: "file://source/bin/cni-netplugin.aci"
+  default: true
+  containerInterface: "veth+{{shortuuid}}"
+  type: bridge
+  bridge: bridge0
+  isGateway: true
+  ipMasq: true
+  ipam:
+    type: host-local
+    subnet: 10.220.0.0/16
+    routes: [ { dst: 0.0.0.0/0 } ]

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$RUN_CONFIG" ]; then
+    echo "kurmad configuration file in RUN_CONFIG not set!"
+    exit 1
+fi
+
+cd $(dirname $0)
+BASE_PATH=`pwd`
+SOURCE_PATH=$(dirname $BASE_PATH)
+
+dir=$(mktemp -d)
+trap "rm -rf $dir" EXIT
+chmod 755 $dir
+
+ln -s $SOURCE_PATH $dir/source
+
+ip=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+
+if [ -n "$IN_DOCKER" ]; then
+    echo "=============================================================="
+    echo "Kurma remote API will be available at $ip:12312"
+    echo
+    echo "To connect with kurma-cli, please run:"
+    echo "  export KURMA_HOST=$ip"
+    echo "=============================================================="
+else
+    echo "=============================================================="
+    echo "Kurma API will be available at $dir/kurma.sock"
+    echo
+    echo "To connect with kurma-cli, please run:"
+    echo "  export KURMA_HOST=$dir/kurma.sock"
+    echo "=============================================================="
+fi
+
+cd $dir
+./source/bin/kurma-server -configFile ./source/$RUN_CONFIG

--- a/kurmad/runner.go
+++ b/kurmad/runner.go
@@ -93,6 +93,22 @@ func (r *runner) configureLogging() error {
 // createDirectories ensures the specified storage paths for pods and volumes
 // exist.
 func (r *runner) createDirectories() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to determine current working directory: %v", err)
+	}
+
+	// Ensure directories are absolute paths
+	if !filepath.IsAbs(r.config.ImagesDirectory) {
+		r.config.ImagesDirectory = filepath.Join(wd, r.config.ImagesDirectory)
+	}
+	if !filepath.IsAbs(r.config.PodsDirectory) {
+		r.config.PodsDirectory = filepath.Join(wd, r.config.PodsDirectory)
+	}
+	if !filepath.IsAbs(r.config.VolumesDirectory) {
+		r.config.VolumesDirectory = filepath.Join(wd, r.config.VolumesDirectory)
+	}
+
 	if err := os.MkdirAll(r.config.ImagesDirectory, os.FileMode(0755)); err != nil {
 		return fmt.Errorf("failed to create images directory: %v", err)
 	}

--- a/stager/container/core/container.go
+++ b/stager/container/core/container.go
@@ -364,7 +364,7 @@ func (cs *containerSetup) createContainers() error {
 		}
 
 		if err := container.Start(process); err != nil {
-			return fmt.Errorf("failed to launch stager process: %v", err)
+			return fmt.Errorf("failed to launch app %q process: %v", name, err)
 		}
 		cs.appMutex.Lock()
 		cs.appProcesses[name] = process


### PR DESCRIPTION
Added 'make help' which will print out a short help message.

Added 'make run' which will launch kurma-server and allow you to connect
up to it. On Linux, it will run it locally and print the path to the
socket. On other, it'll run Docker and print how to connect to the api
proxy.

Added some updates to the readme with documentation on developer setup.

Update the api-proxy ACI to run within the local dev mode.

Update kurmad setup to handle relative paths in the configuration for
directory entries (pods, volumes, images).

@mbhinder @olegshaldybin @jdreno for review