### PR TITLE
Updates for kurmaOS with the pod model

### DIFF
--- a/init/constants.go
+++ b/init/constants.go
@@ -7,6 +7,7 @@ var (
 	// host system to create and manage pods. These functions focus primarily on
 	// runtime actions that must be done each time on boot.
 	setupFunctions = []func(*runner) error{
+		// Basic system startup and configuration
 		(*runner).startSignalHandling,
 		(*runner).switchRoot,
 		(*runner).createSystemMounts,
@@ -15,31 +16,40 @@ var (
 		(*runner).configureEnvironment,
 		(*runner).mountCgroups,
 		(*runner).loadModules,
+
+		// Prepping for starting managers
 		(*runner).createDirectories,
-		(*runner).createImageManager,
-		(*runner).createPodManager,
-		(*runner).startUdev,
+		(*runner).runUdev,
 		(*runner).mountDisks,
 		(*runner).cleanOldPods,
-		(*runner).rescanImages,
+		(*runner).createImageManager,
 		(*runner).loadAvailableImages,
+		(*runner).createPodManager,
+
+		// Final system configuration and mark the boot as successful
 		(*runner).configureHostname,
 		(*runner).configureNetwork,
-		(*runner).createNetworkManager,
 		(*runner).markBootSuccessful,
+
+		// Some early image retrieval before starting initial processes
 		(*runner).setupDiscoveryProxy,
-		(*runner).startNTP,
+		(*runner).prefetchImages,
+
+		// Setup networking plugins
+		(*runner).createNetworkManager,
+
+		// Launch necessary services
 		(*runner).startServer,
-		(*runner).startInitPods,
+		(*runner).rootReadonly,
+		(*runner).startInitialPods,
 		(*runner).displayNetwork,
 		(*runner).startConsole,
-		(*runner).rootReadonly,
 	}
 )
 
 const (
 	// configurationFile is the source of the initial disk based configuration.
-	configurationFile = "/etc/kurma.json"
+	configurationFile = "/etc/kurma.yml"
 
 	// The default location where cgroups should be mounted. This is a constant
 	// because it is referenced in multiple functions.

--- a/kurmad/runner.go
+++ b/kurmad/runner.go
@@ -248,7 +248,7 @@ func (r *runner) startDaemon() error {
 // startInitialPods runs the initial pods from the configuration file.
 func (r *runner) startInitialPods() error {
 	for d, ip := range r.config.InitialPods {
-		name, podManifest, err := ip.process(r)
+		name, podManifest, err := ip.Process(r.imageManager)
 		if name == "" {
 			name = fmt.Sprintf("initial-pod-%d", d+1)
 		}

--- a/pkg/backend/interfaces.go
+++ b/pkg/backend/interfaces.go
@@ -120,11 +120,6 @@ type PodManager interface {
 	// the UUID does not exist.
 	Pod(uuid string) Pod
 
-	// SwapDirectory can be used to temporarily use a different pod path for an
-	// operation. This is a temporary hack util a Pod object can specify its own
-	// path.
-	SwapDirectory(podDirectory string, f func())
-
 	// Shutdown requests that the pod manager shut down running pods to prepare to
 	// exit.
 	Shutdown()

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -5,6 +5,7 @@ package capabilities
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/syndtr/gocapability/capability"
@@ -13,6 +14,41 @@ import (
 var capabilityList []string
 
 func init() {
+	RefreshCapabilities()
+}
+
+func GetAllCapabilities() []string {
+	return capabilityList
+}
+
+// Copied from github.com/syndtr/gocapability, because kurmaOS is started before
+// proc is mounted, this read may fail in its init() func. It is replicated here
+// so we can recalculate the last cap after proc is mounted.
+func initLastCap() (capability.Cap, error) {
+	var capLastCap capability.Cap
+	f, err := os.Open("/proc/sys/kernel/cap_last_cap")
+	if err != nil {
+		return capability.Cap(0), err
+	}
+	defer f.Close()
+
+	var b []byte = make([]byte, 11)
+	_, err = f.Read(b)
+	if err != nil {
+		return capability.Cap(0), err
+	}
+
+	fmt.Sscanf(string(b), "%d", &capLastCap)
+
+	return capLastCap, nil
+}
+
+func RefreshCapabilities() {
+	if lastCap, err := initLastCap(); err == nil {
+		capability.CAP_LAST_CAP = lastCap
+	}
+
+	capabilityList = make([]string, 0)
 	last := capability.CAP_LAST_CAP
 	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
 	if last == capability.Cap(63) {
@@ -24,8 +60,4 @@ func init() {
 		}
 		capabilityList = append(capabilityList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))
 	}
-}
-
-func GetAllCapabilities() []string {
-	return capabilityList
 }

--- a/pkg/networkmanager/driver.go
+++ b/pkg/networkmanager/driver.go
@@ -141,7 +141,9 @@ func (d *networkDriver) call(exec string, args []string, val interface{}) error 
 	// if exit code wasn't 0, return stderr value as the error
 	if exitCode == 0 {
 		if val != nil {
-			return json.Unmarshal(outBytes, &val)
+			if err := json.Unmarshal(outBytes, &val); err != nil {
+				return fmt.Errorf("failed to unmarshal response: %v -- %s", err, string(outBytes))
+			}
 		}
 	} else {
 		return fmt.Errorf("exited %d: %s", exitCode, string(outBytes))

--- a/pkg/podmanager/manager.go
+++ b/pkg/podmanager/manager.go
@@ -269,16 +269,6 @@ func (manager *Manager) Pod(uuid string) backend.Pod {
 	return manager.pods[uuid]
 }
 
-// SwapDirectory can be used to temporarily use a different pod path for
-// an operation. This is a temporary hack util a Pod object can specify
-// its own path.
-func (manager *Manager) SwapDirectory(podDirectory string, f func()) {
-	dir := manager.Options.PodDirectory
-	manager.Options.PodDirectory = podDirectory
-	defer func() { manager.Options.PodDirectory = dir }()
-	f()
-}
-
 // getVolumePath will get the absolute path on the host to the named volume. It
 // will also ensure that the volume name exists within the volumes directory.
 func (manager *Manager) getVolumePath(name string) (string, error) {

--- a/stager/container/core/core.go
+++ b/stager/container/core/core.go
@@ -19,6 +19,7 @@ func Run() error {
 		appWaitch:     make(map[string]chan struct{}),
 	}
 	if err := cs.run(); err != nil {
+		cs.log.Flush()
 		return err
 	}
 	runtime.Goexit()


### PR DESCRIPTION
This includes the code level changes to update kurmaOS to be compatible
with the pods functionality and to update its configuration handling for
parity with kurmad. The build scripts will be added separately.

The changes include:

* Ensure the container stager flushes logs before exiting on error.

* Ensure the set of available capabilities is refreshed in
  `pkg/capabilities` after `/proc` has been mounted in kurmaOS. The
  underlying library has a package `init()` function which was reading
  `/proc` to determine the last capability supported. However with kurmaOS,
  `/proc` is not yet mounted when that will run. This changes the init
  handling to have it refresh after the system mounts are set up.

* Dynamically read the available cgroup mount types from `/proc/cgroups`
  instead of using a hard coded list.

* Added configuration handling for the default stager image, images to
  prefetch, and initial pod setup. The `InitialPodManifest` object from
  kurmad was changed to be publicly exported so it could be shared.

* A helper to generate a new namespace isolator for the pod was moved
  from within `pkg/networkmanager` to be within the `schema` so it could be
  re-used for setting up the console.

* udev has been moved to no longer be a container, but to instead be
  executed from the host. The indirection of launching containers before
  the hardware was initialized was already requiring odd interface
  changes (`PodManager.SwapDirectory`) and just didn't fit into the model
  well. While it is nice to have all services as a container, hardware
  initialization is very core when it comes to requirements like
  extracting images and running containers before your disks may be
  available.

* Removed `PodManager.SwapDirectory()` since it is no longer needed with
  udev moved.

* Removed special configuration around services for
  udev/ntp/console. Console is now top level. NTP should simply be
  defined in `initialPods` rather than be treated special.

* Ensure discovery proxy is only set if one is defined. It was
  initializing the proxy object even when the value was blank.

* Converted base configuration from JSON to YAML. Commenting out parts
  when developing is useful.

Fixes #50 
FYI PR