### PR TITLE
testing: A couple integration test hardness improvements

### DIFF
--- a/testing/integration/lib/kurma/api_client.rb
+++ b/testing/integration/lib/kurma/api_client.rb
@@ -15,6 +15,7 @@ class Kurma::ApiClient
   attr_reader :client
 
   def initialize
+    JSONRPC.logger = Kurma::LOG
     @client = JSONRPC::Client.new('http://example.com/rpc')
   end
 

--- a/testing/integration/lib/kurma/cli_client.rb
+++ b/testing/integration/lib/kurma/cli_client.rb
@@ -14,11 +14,15 @@ class Kurma::CliClient
     Kurma::LOG
   end
 
+  def cli_binary
+    @cli_binary ||= File.join(File.dirname(__FILE__), "..", "..", "..", "..", "bin", "kurma-cli")
+  end
+
   # @param [String] cmd
   # @return [String, String, Process::Status]
   def run(cmd, *args)
     env = { }
-    cmd_line = "kurma-cli #{cmd}"
+    cmd_line = "#{self.cli_binary} #{cmd}"
     if cmd_line.include? " -- "
       # Command contains extended parameters, so put --show-panics before the extended parameters
       #cmd_line.sub! " -- ", " --show-panics -- "
@@ -46,7 +50,7 @@ class Kurma::CliClient
   # @return [Int] exit_status
   def run_with_prompts!(cmd, prompts = {})
     env = { }
-    cmd_line = "kurma-cli #{cmd}"
+    cmd_line = "#{self.cli_binary} #{cmd}"
     if cmd_line.include? " -- "
       # Command contains extended parameters, so put --show-panics before the extended parameters
       #cmd_line.sub! " -- ", " --show-panics -- "
@@ -107,7 +111,7 @@ class Kurma::CliClient
   # @param [String] cmd
   def start(cmd, *args)
     env = { }
-    cmd_line = "kurma-cli #{cmd}"
+    cmd_line = "#{self.cli_binary} #{cmd}"
     logger.info { "==> #{cmd_line}" }
 
     stdin_data = args.empty? ? nil : args.join("\n") + "\n"

--- a/testing/integration/lib/kurma/server.rb
+++ b/testing/integration/lib/kurma/server.rb
@@ -10,7 +10,7 @@ class Kurma::Server
   end
 
   def kurma_binary
-    ENV["KURMAD_BINARY"] || "kurma-server"
+    ENV["KURMAD_BINARY"] || File.join(File.dirname(__FILE__), "..", "..", "..", "..", "bin", "kurma-server")
   end
 
   def kurma_logfile

--- a/testing/integration/spec/create_spec.rb
+++ b/testing/integration/spec/create_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe "CLI create" do
     initial_pods_count = api.list_pods["pods"].size
 
     output = cli.run!("create coreos.com/etcd:v2.2.5")
-    expect(output).to include("Launched pod")
+    uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
+    expect(uuid).not_to be_nil
 
     resp = api.list_pods
     expect(resp["pods"].size).to eq(initial_pods_count+1)
 
-    output = cli.run!("stop #{resp["pods"].first["uuid"]}")
+    output = cli.run!("stop #{uuid}")
     expect(output).to include("Destroyed pod")
 
     resp = api.list_pods
@@ -22,12 +23,13 @@ RSpec.describe "CLI create" do
     initial_pods_count = api.list_pods["pods"].size
 
     output = cli.run!("create docker://nats")
-    expect(output).to include("Launched pod")
+    uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
+    expect(uuid).not_to be_nil
 
     resp = api.list_pods
     expect(resp["pods"].size).to eq(initial_pods_count+1)
 
-    output = cli.run!("stop #{resp["pods"].first["uuid"]}")
+    output = cli.run!("stop #{uuid}")
     expect(output).to include("Destroyed pod")
 
     resp = api.list_pods


### PR DESCRIPTION
This addresses a few improvements with the integration tests.

* Redirect the HTTP request logging to the test log. Reduces noise in
  the testing output and puts it in line with the other calls in the
  log.
* Use the CLI/kurmad binaries from the repositories bin directory rather
  than finding them on the path. This makes running the tests simpler.
* Update the create_spec.rb tests to get the created pod's UUID from the
  create calls output, rather than assuming its the first pod returned
  from the API. It could be easily stopping a pod that wasn't the one it
  started.

FYI PR