### PR TITLE
Add support for populating the resolv.conf in pods

### DIFF
--- a/pkg/podmanager/dnsconfig_unix.go
+++ b/pkg/podmanager/dnsconfig_unix.go
@@ -1,0 +1,69 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
+
+package podmanager
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/appc/cni/pkg/types"
+)
+
+// See resolv.conf(5) on a Linux machine.
+// Based on the same function from Go src/net/dnsconfig_unix.go
+func dnsReadConfig(filename string) (*types.DNS, error) {
+	conf := &types.DNS{}
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) > 0 && (line[0] == ';' || line[0] == '#') {
+			// comment.
+			continue
+		}
+		f := strings.Fields(line)
+		if len(f) < 1 {
+			continue
+		}
+		switch f[0] {
+		case "nameserver": // add one name server
+			if len(f) > 1 && len(conf.Nameservers) < 3 { // small, but the standard limit
+				// One more check: make sure server name is
+				// just an IP address.  Otherwise we need DNS
+				// to look it up.
+				if net.ParseIP(f[1]) != nil {
+					conf.Nameservers = append(conf.Nameservers, f[1])
+				}
+			}
+
+		case "domain": // set search path to just this domain
+			if len(f) > 1 {
+				conf.Domain = f[1]
+			}
+
+		case "search": // set search path to given servers
+			conf.Search = make([]string, len(f)-1)
+			for i := 0; i < len(conf.Search); i++ {
+				conf.Search[i] = f[i+1]
+			}
+
+		case "options": // magic options
+			conf.Options = make([]string, len(f)-1)
+			for i := 0; i < len(conf.Options); i++ {
+				conf.Options[i] = f[i+1]
+			}
+
+		}
+	}
+
+	return conf, nil
+}

--- a/pkg/podmanager/operations_test.go
+++ b/pkg/podmanager/operations_test.go
@@ -3,8 +3,10 @@
 package podmanager
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/apcera/kurma/pkg/backend"
@@ -13,7 +15,9 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
 
+	ntypes "github.com/apcera/kurma/pkg/networkmanager/types"
 	tt "github.com/apcera/util/testtool"
+	cnitypes "github.com/appc/cni/pkg/types"
 )
 
 func createPod(t *testing.T, manager *Manager) *Pod {
@@ -90,6 +94,67 @@ func TestStartingInitializeContainer(t *testing.T) {
 	tt.TestExpectSuccess(t, pod.startingInitializeContainer())
 
 	tt.TestEqual(t, len(factory.containers), 1)
+}
+
+func TestStartingResolvConf(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	manager := createManager(t)
+	pod := createPod(t, manager)
+	pod.stagerPath = tt.TempDir(t)
+	pod.manifest = &backend.StagerManifest{
+		Pod: schema.BlankPodManifest(),
+	}
+
+	// setup some mock networking
+	pod.networkResults = []*ntypes.IPResult{
+		&ntypes.IPResult{
+			DNS: &cnitypes.DNS{
+				Search:      []string{"cluster.example.local"},
+				Nameservers: []string{"1.2.3.4", "5.6.7.8"},
+			},
+		},
+	}
+
+	tt.TestExpectSuccess(t, pod.startingBaseDirectories())
+	tt.TestExpectSuccess(t, pod.startingResolvConf())
+
+	resolvConf, err := ioutil.ReadFile(filepath.Join(pod.stagerRootPath(), "etc", "resolv.conf"))
+	tt.TestExpectSuccess(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(resolvConf)), "\n")
+	tt.TestEqual(t, len(lines), 3)
+	tt.TestEqual(t, lines[0], "search cluster.example.local")
+	tt.TestEqual(t, lines[1], "nameserver 1.2.3.4")
+	tt.TestEqual(t, lines[2], "nameserver 5.6.7.8")
+}
+
+func TestStartingResolvConf_UsingHosts(t *testing.T) {
+	tt.StartTest(t)
+	defer tt.FinishTest(t)
+
+	manager := createManager(t)
+	pod := createPod(t, manager)
+	pod.stagerPath = tt.TempDir(t)
+	pod.manifest = &backend.StagerManifest{
+		Pod: schema.BlankPodManifest(),
+	}
+
+	tt.TestExpectSuccess(t, pod.startingBaseDirectories())
+	tt.TestExpectSuccess(t, pod.startingResolvConf())
+
+	// read the resolv conf from the host
+	hostDNS, err := dnsReadConfig("/etc/resolv.conf")
+	tt.TestExpectSuccess(t, err)
+	tt.TestNotEqual(t, len(hostDNS.Nameservers), 0, "the host should have >0 nameservers")
+
+	// read the stager's resolv conf
+	stagerDNS, err := dnsReadConfig(filepath.Join(pod.stagerRootPath(), "etc", "resolv.conf"))
+	tt.TestExpectSuccess(t, err)
+
+	// stager's nameservers should match the host's
+	tt.TestEqual(t, hostDNS.Nameservers, stagerDNS.Nameservers)
 }
 
 func TestLaunchStager(t *testing.T) {

--- a/pkg/podmanager/pod.go
+++ b/pkg/podmanager/pod.go
@@ -16,6 +16,7 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/opencontainers/runc/libcontainer"
 
+	ntypes "github.com/apcera/kurma/pkg/networkmanager/types"
 	kschema "github.com/apcera/kurma/schema"
 )
 
@@ -25,7 +26,8 @@ type Pod struct {
 	manager *Manager
 	log     *logray.Logger
 
-	netNsPath string
+	netNsPath      string
+	networkResults []*ntypes.IPResult
 
 	stagerPath      string
 	stagerImage     *schema.ImageManifest

--- a/stager/container/core/util.go
+++ b/stager/container/core/util.go
@@ -69,6 +69,12 @@ var (
 			Device:      "cgroup",
 			Flags:       defaultMountFlags | syscall.MS_RDONLY,
 		},
+		{
+			Source:      "/etc/resolv.conf",
+			Destination: "/etc/resolv.conf",
+			Device:      "bind",
+			Flags:       syscall.MS_BIND | syscall.MS_RDONLY,
+		},
 	}
 )
 

--- a/testing/integration/spec/networking_spec.rb
+++ b/testing/integration/spec/networking_spec.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+require 'spec_helper'
+
+RSpec.describe "Container networking" do
+  it "should create a resolv.conf for containers" do
+    output = cli.run!("create docker://busybox --name busybox --net=host /bin/sleep 60")
+    uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
+    expect(uuid).not_to be_nil
+
+    output = cli.run!("enter #{uuid} busybox", "cat /etc/resolv.conf", "exit")
+    output.gsub!("\r", "") # trim carriage returns
+    expect(output).to match(/^nameserver \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)
+
+    output = cli.run!("stop #{uuid}")
+    expect(output).to include("Destroyed pod")
+  end
+end


### PR DESCRIPTION
This adds support for populating the resolv.conf in the podmanager
when it is setting up the stager. It will look for a returned DNS
configuration from the networkmanager and use that. If none is found,
then it will parse the host's resolv.conf and use that to write a
resolv.conf for the stager. It does this rather than mount in the
resolv.conf to ensure it is scoped to the necessary settings.

The stager has also been updated to simply bind mount its resolv.conf
into the individual applications. It is mounted as read only so apps
cannot alter it.

Unit tests added around the podmanager's setup for the
stager. Integration test added to ensure it works all the way down
through to the app containers.

A small change was included to allow `kurma-cli create` to take
additional arguments which will override the package's default Exec
command.

FYI PR
Fixes #48 