### PR TITLE
stager/container: Ensure output is written before exiting

### DIFF
--- a/testing/integration/spec/create_spec.rb
+++ b/testing/integration/spec/create_spec.rb
@@ -35,4 +35,17 @@ RSpec.describe "CLI create" do
     resp = api.list_pods
     expect(resp["pods"].size).to eq(initial_pods_count)
   end
+
+  it "should enter a container and run a command" do
+    output = cli.run!("create docker://busybox --name busybox --net=host /bin/sleep 60")
+    uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
+    expect(uuid).not_to be_nil
+
+    output = cli.run!("enter #{uuid} busybox", "whoami", "exit")
+    output.gsub!("\r", "") # trim carriage returns
+    expect(output).to match("whoami\nroot")
+
+    output = cli.run!("stop #{uuid}")
+    expect(output).to include("Destroyed pod")
+  end
 end


### PR DESCRIPTION
This fixes an issue where the 'run' callin to the container stager could
exit when the child process is done, but not before the goroutines to
copy data over the tty are finished writing.

This adds a waitgroup around copying from the tty to stdout and ensures
it has finished before the process exits.

Additionally, added a simple integration test that will enter a
container and simply run `whoami`. This is just a simpler test to
validate the 'enter' command than testing the resolv.conf writing.

Fixes #56 