### PR TITLE
kurma-cli enter would panic if user did not specify all three: UUID,

### DIFF
--- a/pkg/cli/commands/enter.go
+++ b/pkg/cli/commands/enter.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func cmdEnter(cmd *cobra.Command, args []string) {
-	if len(args) == 0 {
+	if len(args) < 2 {
 		fmt.Printf("Invalid command options specified.\n")
 		cmd.Help()
 		return
@@ -39,12 +39,22 @@ func cmdEnter(cmd *cobra.Command, args []string) {
 		defer raw.TcSetAttr(os.Stdin.Fd(), termios)
 	}
 
-	app := &schema.RunApp{
-		WorkingDirectory: "/",
-		User:             "0",
-		Group:            "0",
-		Exec:             args[2:],
-		Tty:              true,
+	var app *schema.RunApp
+	if len(args) > 2 {
+		app = &schema.RunApp{
+			WorkingDirectory: "/",
+			User:             "0",
+			Group:            "0",
+			Exec:             args[2:],
+			Tty:              true,
+		}
+	} else {
+		app = &schema.RunApp{
+			WorkingDirectory: "/",
+			User:             "0",
+			Group:            "0",
+			Tty:              true,
+		}
 	}
 
 	// Initialize the reader/writer


### PR DESCRIPTION
@krobertson I was not able to do a cli enter. This fix works but only for the "bridge" network plugin pod. It does not work for any other pods I create. This is the error I get, looks like it's looking for bin/sh. 

ERR: exec: "/bin/sh": stat /bin/sh: no such file or directory