### PR TITLE
build: Change all references to ACI names to use kurma.io

### DIFF
--- a/Documentation/network_specification.md
+++ b/Documentation/network_specification.md
@@ -32,7 +32,7 @@ configuration.
   "pod_networks": [
     {
       "name": "mynet",
-      "aci": "apcera.com/kurma/cni-netplugin",
+      "aci": "kurma.io/cni-netplugin",
       "default": true,
       "containerInterface": "eth0",
       "type": "bridge",

--- a/build/aci/console/manifest.yaml
+++ b/build/aci/console/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-name: apcera.com/kurma/console
+name: kurma.io/console
 app:
   exec:
   - /start.sh
@@ -18,4 +18,4 @@ app:
   - name: os/linux/privileged
     value: true
 dependencies:
-  - imageName: apcera.com/kurma/busybox
+  - imageName: kurma.io/busybox

--- a/build/aci/kurma-api/manifest.yaml
+++ b/build/aci/kurma-api/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-name: apcera.com/kurma/api
+name: kurma.io/api
 app:
   exec:
   - /kurma-api

--- a/build/aci/kurma-stager-container/manifest.yaml
+++ b/build/aci/kurma-stager-container/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-name: apcera.com/kurma/stager/container
+name: kurma.io/stager/container
 app:
   exec:
   - /stager

--- a/build/aci/kurma-upgrader/manifest.yaml
+++ b/build/aci/kurma-upgrader/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-name: apcera.com/kurma/upgrader
+name: kurma.io/upgrader
 app:
   exec:
   - /kurma-upgrader

--- a/build/kurma-init/kurma.yml
+++ b/build/kurma-init/kurma.yml
@@ -7,7 +7,7 @@ oemConfig:
 # Base system configuration
 hostname: kurmaos
 parentCgroupName: kurma
-defaultStagerImage: apcera.com/kurma/stager/container
+defaultStagerImage: kurma.io/stager/container
 modules:
   - nf_nat
   - bridge
@@ -40,12 +40,12 @@ networkConfig:
 console:
   enabled: true
   password: kurma
-  aci: apcera.com/kurma/console
+  aci: kurma.io/console
 
 # Configure pod networking plugins
 podNetworks:
   - name: bridge
-    aci: apcera.com/kurma/cni-netplugin
+    aci: kurma.io/cni-netplugin
     default: true
     containerInterface: "veth+{{shortuuid}}"
     type: bridge
@@ -63,7 +63,7 @@ initialPods:
     apps:
       - name: kurma-api
         image:
-          name: apcera.com/kurma/api
+          name: kurma.io/api
     isolators:
       - name: os/linux/namespaces
         value:

--- a/build/local-kurmad.yml
+++ b/build/local-kurmad.yml
@@ -24,7 +24,7 @@ initialPods:
   apps:
   - name: api-proxy
     image:
-      name: apcera.com/kurma/api
+      name: kurma.io/api
   isolators:
   - name: os/linux/namespaces
     value:


### PR DESCRIPTION
This moves the image name references from apcera.com/kurma/* to using
kurma.io.