### PR TITLE
Add network information to Pod object returned over the API.

### DIFF
--- a/pkg/apiclient/types.go
+++ b/pkg/apiclient/types.go
@@ -6,14 +6,16 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
 
+	ntypes "github.com/apcera/kurma/pkg/networkmanager/types"
 	kschema "github.com/apcera/kurma/schema"
 )
 
 type Pod struct {
-	UUID  string              `json:"uuid"`
-	Name  string              `json:"name"`
-	Pod   *schema.PodManifest `json:"pod"`
-	State State               `json:"state"`
+	UUID     string              `json:"uuid"`
+	Name     string              `json:"name"`
+	Pod      *schema.PodManifest `json:"pod"`
+	Networks []*ntypes.IPResult  `json:"networks"`
+	State    State               `json:"state"`
 }
 
 type Image struct {

--- a/pkg/backend/interfaces.go
+++ b/pkg/backend/interfaces.go
@@ -199,6 +199,9 @@ type Pod interface {
 	// PodManifest returns the current pod manifest for the App Pod Specification.
 	PodManifest() *schema.PodManifest
 
+	// Networks returns the configured network results for the pod.
+	Networks() []*ntypes.IPResult
+
 	// State returns the current operating state of the pod.
 	State() PodState
 

--- a/pkg/daemon/pod_service.go
+++ b/pkg/daemon/pod_service.go
@@ -57,9 +57,10 @@ func (s *PodService) Destroy(r *http.Request, uuid *string, ret *apiclient.None)
 
 func exportPod(c backend.Pod) *apiclient.Pod {
 	return &apiclient.Pod{
-		UUID:  c.UUID(),
-		Name:  c.Name(),
-		Pod:   c.PodManifest(),
-		State: apiclient.State(c.State().String()),
+		UUID:     c.UUID(),
+		Name:     c.Name(),
+		Pod:      c.PodManifest(),
+		Networks: c.Networks(),
+		State:    apiclient.State(c.State().String()),
 	}
 }

--- a/pkg/podmanager/pod.go
+++ b/pkg/podmanager/pod.go
@@ -60,7 +60,16 @@ type Pod struct {
 // PodManifest returns the current pod manifest for the App Pod
 // Specification.
 func (pod *Pod) PodManifest() *schema.PodManifest {
+	pod.mutex.Lock()
+	defer pod.mutex.Unlock()
 	return pod.manifest.Pod
+}
+
+// Networks returns the configured network results for the pod.
+func (pod *Pod) Networks() []*ntypes.IPResult {
+	pod.mutex.Lock()
+	defer pod.mutex.Unlock()
+	return pod.networkResults
 }
 
 // State returns the current operating state of the pod.


### PR DESCRIPTION
This adds the network results object to the Pod object returned by the
daemon's API. This allows visibility into the network information
configured for a pod.

Note: when sharing the host's network namespace, the network info will
be empty, as nothing was configured for that pod.

FYI PR