### PR TITLE
podmanager: Ensure cgroups mounts are private

### DIFF
--- a/pkg/podmanager/utils.go
+++ b/pkg/podmanager/utils.go
@@ -70,8 +70,9 @@ func (pod *Pod) generateContainerConfig() (*configs.Config, error) {
 				Flags:       defaultMountFlags | syscall.MS_RDONLY,
 			},
 			{
-				Destination: "/sys/fs/cgroup",
-				Device:      "cgroup",
+				Destination:      "/sys/fs/cgroup",
+				Device:           "cgroup",
+				PropagationFlags: []int{syscall.MS_PRIVATE},
 			},
 		},
 	}


### PR DESCRIPTION
On some platforms, such as Ubuntu Xenial, the cgroups location defaults
to being shared. The mapping in of cgroups can then cause an exponential
growth of the mountinfo file which causes large CPU spikes parsing it on
container spin up.

This ensures the cgroups mounts that are mapped in are private and do
not propagate. This is controlled just at the launching of the stager by
the podmanager.

FIY @schancel @mbhinder 