### PR TITLE
spec: Fix container shutdown to be a cleanup operation

### DIFF
--- a/testing/integration/spec/create_spec.rb
+++ b/testing/integration/spec/create_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "CLI create" do
     output = cli.run!("create coreos.com/etcd:v2.2.5")
     uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
     expect(uuid).not_to be_nil
+    @cleanup << "stop #{uuid}"
 
     resp = api.list_pods
     expect(resp["pods"].size).to eq(initial_pods_count+1)
@@ -25,27 +26,20 @@ RSpec.describe "CLI create" do
     output = cli.run!("create docker://nats")
     uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
     expect(uuid).not_to be_nil
+    @cleanup << "stop #{uuid}"
 
     resp = api.list_pods
     expect(resp["pods"].size).to eq(initial_pods_count+1)
-
-    output = cli.run!("stop #{uuid}")
-    expect(output).to include("Destroyed pod")
-
-    resp = api.list_pods
-    expect(resp["pods"].size).to eq(initial_pods_count)
   end
 
   it "should enter a container and run a command" do
     output = cli.run!("create docker://busybox --name busybox --net=host /bin/sleep 60")
     uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
     expect(uuid).not_to be_nil
+    @cleanup << "stop #{uuid}"
 
     output = cli.run!("enter #{uuid} busybox", "whoami", "exit")
     output.gsub!("\r", "") # trim carriage returns
     expect(output).to match("whoami\nroot")
-
-    output = cli.run!("stop #{uuid}")
-    expect(output).to include("Destroyed pod")
   end
 end

--- a/testing/integration/spec/networking_spec.rb
+++ b/testing/integration/spec/networking_spec.rb
@@ -6,12 +6,10 @@ RSpec.describe "Container networking" do
     output = cli.run!("create docker://busybox --name busybox --net=host /bin/sleep 60")
     uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
     expect(uuid).not_to be_nil
+    @cleanup << "stop #{uuid}"
 
     output = cli.run!("enter #{uuid} busybox", "cat /etc/resolv.conf", "exit")
     output.gsub!("\r", "") # trim carriage returns
     expect(output).to match(/^nameserver \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)
-
-    output = cli.run!("stop #{uuid}")
-    expect(output).to include("Destroyed pod")
   end
 end


### PR DESCRIPTION
Change container teardown in the integration tests to be a part of the
cleanup operations. This ensures that the containers are stopped even in
the case of a test failure, since otherwise if there is a failure, the
remaining steps won't run.

@zquestz @mbhinder 