### PR TITLE
Add support for aufs to graphstorage.

### DIFF
--- a/pkg/daemon/general_service.go
+++ b/pkg/daemon/general_service.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/apcera/kurma/pkg/apiclient"
+	"github.com/apcera/kurma/pkg/misc"
 	"github.com/appc/spec/schema"
 )
 
@@ -22,7 +23,7 @@ func (s *Server) infoRequest(w http.ResponseWriter, req *http.Request) {
 		Arch:          runtime.GOARCH,
 		ACVersion:     schema.AppContainerVersion,
 		KurmaVersion:  apiclient.KurmaVersion,
-		KernelVersion: getKernelVersion(),
+		KernelVersion: misc.GetKernelVersion(),
 	}
 
 	hostname, err := os.Hostname()

--- a/pkg/graphstorage/aufs/aufs.go
+++ b/pkg/graphstorage/aufs/aufs.go
@@ -1,0 +1,143 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package aufs
+
+import "C"
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/apcera/kurma/pkg/graphstorage"
+	"github.com/apcera/kurma/pkg/misc"
+	"github.com/apcera/util/proc"
+)
+
+type aufsProvisioner struct {
+}
+
+// New returns a new graph storage provisioner that uses the aufs filesystem
+// module for doing a union fileysstem.
+func New() (graphstorage.StorageProvisioner, error) {
+	// ensure aufs filesystem is available
+	if err := loadAufsSupport(); err != nil {
+		return nil, err
+	}
+
+	return &aufsProvisioner{}, nil
+}
+
+// Create will trigger the creation of an aufs mount at the specified
+// location and with the included base containers in a new mount namespace. It
+// will return a PodStorage object on success, or an error on any failures.
+func (o *aufsProvisioner) Create(target string, imagedefintion []string) error {
+	scratch, err := ioutil.TempDir(os.TempDir(), "scratch")
+	if err != nil {
+		return fmt.Errorf("failed to create aufs write branch: %v", err)
+	}
+
+	// Mount the read/write portion of aufs first.
+	err = syscall.Mount("none", target, "aufs", syscall.MS_MGC_VAL, fmt.Sprintf("br=%s=rw", scratch))
+	if err != nil {
+		return fmt.Errorf("failed to mount aufs write branch: %v", err)
+	}
+
+	// Mount each layer individually. Doing them as separate calls avoids issues
+	// with a single mount call with a lot of layers failing.
+	for _, imagePath := range imagedefintion {
+		err := syscall.Mount("none", target, "aufs", syscall.MS_REMOUNT, fmt.Sprintf("append:%s=ro+wh", imagePath))
+		if err != nil {
+			return fmt.Errorf("failed to mount layer %q: %v", imagePath, err)
+		}
+	}
+
+	return nil
+}
+
+// loadAufsSupport will ensure the aufs filesystem is available for use. It will
+// return an error if it is unavailable or fails to load the associated kernel
+// module.
+func loadAufsSupport() error {
+	// Check to see if aufs is already available. It could be compiled into the
+	// kernel, or the module could be already loaded.
+	avail, err := checkIfAufsIsAvailable()
+	if err != nil {
+		return fmt.Errorf("failed to check if aufs filesystem was supported: %v", err)
+	}
+	if avail {
+		return nil
+	}
+
+	// If the filesystem type isn't available, then check if the module is available
+	avail, err = checkIfAufsModuleAvailable()
+	if err != nil {
+		return fmt.Errorf("failed to check if aufs module is available: %v", err)
+	}
+	if !avail {
+		return fmt.Errorf("aufs module is not available")
+	}
+
+	// It is not available yet, so load the module.
+	if b, err := exec.Command("modprobe", "aufs").CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to load the aufs module: %s - %v", string(b), err)
+	}
+
+	// recheck that it is available
+	avail, err = checkIfAufsIsAvailable()
+	if err != nil {
+		return fmt.Errorf("failed to check if aufs filesystem was supported: %v", err)
+	}
+	if !avail {
+		return fmt.Errorf("aufs filesystem support unavailable after loading the module")
+	}
+	return nil
+}
+
+// checkIfAufsIsAvailable scans the /proc/filesystems file to see if aufs is
+// listed as a filesystem type that is available.
+func checkIfAufsIsAvailable() (bool, error) {
+	available := false
+	err := proc.ParseSimpleProcFile("/proc/filesystems", nil,
+		func(line, index int, elem string) error {
+			if elem == "aufs" {
+				available = true
+			}
+			return nil
+		},
+	)
+	return available, err
+}
+
+// checkIfAufsModuleAvailable checks if the aufs module is available in
+// the modules.alias file. This is more efficient than attempting to load the
+// module when it doesn't exist.
+func checkIfAufsModuleAvailable() (bool, error) {
+	aliasPath := filepath.Join("/lib/modules", misc.GetKernelVersion(), "modules.alias")
+	f, err := os.Open(aliasPath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) < 3 {
+			continue
+		}
+		if parts[0] != "alias" {
+			continue
+		}
+		if parts[len(parts)-1] != "aufs" {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/graphstorage/aufs/aufs.go
+++ b/pkg/graphstorage/aufs/aufs.go
@@ -33,10 +33,10 @@ func New() (graphstorage.StorageProvisioner, error) {
 	return &aufsProvisioner{}, nil
 }
 
-// Create will trigger the creation of an aufs mount at the specified
-// location and with the included base containers in a new mount namespace. It
-// will return a PodStorage object on success, or an error on any failures.
-func (o *aufsProvisioner) Create(target string, imagedefintion []string) error {
+// Create will trigger the creation of an aufs mount at the specified location
+// and with the included base image paths. It will return an error on any
+// failures.
+func (o *aufsProvisioner) Create(target string, imagedefinition []string) error {
 	scratch, err := ioutil.TempDir(os.TempDir(), "scratch")
 	if err != nil {
 		return fmt.Errorf("failed to create aufs write branch: %v", err)
@@ -50,7 +50,7 @@ func (o *aufsProvisioner) Create(target string, imagedefintion []string) error {
 
 	// Mount each layer individually. Doing them as separate calls avoids issues
 	// with a single mount call with a lot of layers failing.
-	for _, imagePath := range imagedefintion {
+	for _, imagePath := range imagedefinition {
 		err := syscall.Mount("none", target, "aufs", syscall.MS_REMOUNT, fmt.Sprintf("append:%s=ro+wh", imagePath))
 		if err != nil {
 			return fmt.Errorf("failed to mount layer %q: %v", imagePath, err)

--- a/pkg/graphstorage/overlay/overlay.go
+++ b/pkg/graphstorage/overlay/overlay.go
@@ -34,9 +34,9 @@ func New() (graphstorage.StorageProvisioner, error) {
 }
 
 // Create will trigger the creation of an overlay mount at the specified
-// location and with the included base containers in a new mount namespace. It
-// will return a PodStorage object on success, or an error on any failures.
-func (o *overlayProvisioner) Create(target string, imagedefintion []string) error {
+// location and with the included base image paths. It will return an error on
+// any failures.
+func (o *overlayProvisioner) Create(target string, imagedefinition []string) error {
 	upper, err := ioutil.TempDir(os.TempDir(), "upper")
 	if err != nil {
 		return err
@@ -46,7 +46,7 @@ func (o *overlayProvisioner) Create(target string, imagedefintion []string) erro
 		return err
 	}
 
-	lower := strings.Join(imagedefintion, ":")
+	lower := strings.Join(imagedefinition, ":")
 	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
 	if err := syscall.Mount("overlay", target, "overlay", 0, opts); err != nil {
 		return fmt.Errorf("failed to mount storage: %v", err)

--- a/pkg/misc/kernelversion.go
+++ b/pkg/misc/kernelversion.go
@@ -1,16 +1,16 @@
 // Copyright 2016 Apcera Inc. All rights reserved.
 // getKernelVersion Copyright 2014 Google Inc. All Rights Reserved.
 
-package daemon
+package misc
 
 import (
 	"bytes"
 	"syscall"
 )
 
-// getKernelVersion parses the result from uname() into a string representation
+// GetKernelVersion parses the result from uname() into a string representation
 // of the kernel version.
-func getKernelVersion() string {
+func GetKernelVersion() string {
 	uname := &syscall.Utsname{}
 	if err := syscall.Uname(uname); err != nil {
 		return "Unknown"


### PR DESCRIPTION
This adds support for aufs as a graphstorage implementation. This
enables Kurma to work on Ubuntu 14.04 and 12.04.

The container stager has also been updated to default to automatically
detecting which driver to use, if one isn't explicitly defined.

A few updates have been made to the Ubuntu packer definitions for Ubuntu
14.04 and 12.04. On both, the cgroup-lite package was installed to
ensure all cgroups mounts are available on boot. Additionally, the 12.04
defintion will install the 3.13 kernel from Ubuntu trusty. By default,
12.04 used the 3.2 kernel, which is older than kernels typically
recommended for container workloads for full and stable functionality.

Fixes #33.

@alextoombs @mbhinder 