### PR TITLE
build: Updates to build images for kernel and Go

### DIFF
--- a/build/docker/kurma-kernel/build.sh
+++ b/build/docker/kurma-kernel/build.sh
@@ -12,8 +12,8 @@ emerge --sync
 emerge sys-kernel/linux-firmware
 
 # allow the proper kernel version
-echo '=sys-kernel/vanilla-sources-4.4.11 ~amd64' >> /etc/portage/package.accept_keywords
-emerge =sys-kernel/vanilla-sources-4.4.11
+echo '=sys-kernel/vanilla-sources-4.6.2 ~amd64' >> /etc/portage/package.accept_keywords
+emerge =sys-kernel/vanilla-sources-4.6.2
 mv /tmp/kernel.defconfig /usr/src/linux/.config
 
 cd /usr/src/linux

--- a/build/docker/kurma-kernel/patches/0002-security-provide-copy-up-security-hooks.patch
+++ b/build/docker/kurma-kernel/patches/0002-security-provide-copy-up-security-hooks.patch
@@ -1,7 +1,8 @@
-From 70aadec167cb84865c6e85c1eccc218a024f86ef Mon Sep 17 00:00:00 2001
+From 21bb922ca499884980a7a98992bb0b00c05c223a Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Tue, 16 Jun 2015 14:14:31 +0100
-Subject: [PATCH] Security: Provide copy-up security hooks for unioned files
+Subject: [PATCH] Security: Provide copy-up security hooks for unioned
+ files
 
 Provide two new security hooks for use with security files that are used when
 a file is copied up between layers:
@@ -20,7 +21,7 @@ Signed-off-by: David Howells <dhowells@redhat.com>
  3 files changed, 54 insertions(+)
 
 diff --git a/include/linux/lsm_hooks.h b/include/linux/lsm_hooks.h
-index ec3a6bab..8c0c524 100644
+index cdee11c..adef596 100644
 --- a/include/linux/lsm_hooks.h
 +++ b/include/linux/lsm_hooks.h
 @@ -401,6 +401,24 @@
@@ -48,17 +49,17 @@ index ec3a6bab..8c0c524 100644
   *
   * Security hooks for file operations
   *
-@@ -1421,6 +1439,9 @@ union security_list_options {
+@@ -1424,6 +1442,9 @@ union security_list_options {
  	int (*inode_listsecurity)(struct inode *inode, char *buffer,
  					size_t buffer_size);
- 	void (*inode_getsecid)(const struct inode *inode, u32 *secid);
+ 	void (*inode_getsecid)(struct inode *inode, u32 *secid);
 +	int (*inode_copy_up) (struct dentry *src, struct dentry *dst);
 +	int (*inode_copy_up_xattr) (struct dentry *src, struct dentry *dst,
 +				    const char *name, void *value, size_t *size);
  
  	int (*file_permission)(struct file *file, int mask);
  	int (*file_alloc_security)(struct file *file);
-@@ -1689,6 +1710,8 @@ struct security_hook_heads {
+@@ -1695,6 +1716,8 @@ struct security_hook_heads {
  	struct list_head inode_setsecurity;
  	struct list_head inode_listsecurity;
  	struct list_head inode_getsecid;
@@ -68,13 +69,13 @@ index ec3a6bab..8c0c524 100644
  	struct list_head file_alloc_security;
  	struct list_head file_free_security;
 diff --git a/include/linux/security.h b/include/linux/security.h
-index 2f4c1f7a..ec21144 100644
+index 157f0cb..449f1b0 100644
 --- a/include/linux/security.h
 +++ b/include/linux/security.h
-@@ -274,6 +274,10 @@ int security_inode_getsecurity(const struct inode *inode, const char *name, void
+@@ -276,6 +276,10 @@ int security_inode_getsecurity(struct inode *inode, const char *name, void **buf
  int security_inode_setsecurity(struct inode *inode, const char *name, const void *value, size_t size, int flags);
  int security_inode_listsecurity(struct inode *inode, char *buffer, size_t buffer_size);
- void security_inode_getsecid(const struct inode *inode, u32 *secid);
+ void security_inode_getsecid(struct inode *inode, u32 *secid);
 +int security_inode_copy_up(struct dentry *src, struct dentry *dst);
 +int security_inode_copy_up_xattr(struct dentry *src, struct dentry *dst,
 +				 const char *name, void *value, size_t *size);
@@ -82,7 +83,7 @@ index 2f4c1f7a..ec21144 100644
  int security_file_permission(struct file *file, int mask);
  int security_file_alloc(struct file *file);
  void security_file_free(struct file *file);
-@@ -739,6 +743,16 @@ static inline void security_inode_getsecid(const struct inode *inode, u32 *secid
+@@ -744,6 +748,16 @@ static inline void security_inode_getsecid(struct inode *inode, u32 *secid)
  	*secid = 0;
  }
  
@@ -100,10 +101,10 @@ index 2f4c1f7a..ec21144 100644
  {
  	return 0;
 diff --git a/security/security.c b/security/security.c
-index 46f405c..e33c5d5 100644
+index 3644b03..8548340 100644
 --- a/security/security.c
 +++ b/security/security.c
-@@ -726,6 +726,19 @@ void security_inode_getsecid(const struct inode *inode, u32 *secid)
+@@ -726,6 +726,19 @@ void security_inode_getsecid(struct inode *inode, u32 *secid)
  	call_void_hook(inode_getsecid, inode, secid);
  }
  
@@ -123,7 +124,7 @@ index 46f405c..e33c5d5 100644
  int security_file_permission(struct file *file, int mask)
  {
  	int ret;
-@@ -1654,6 +1667,10 @@ struct security_hook_heads security_hook_heads = {
+@@ -1662,6 +1675,10 @@ struct security_hook_heads security_hook_heads = {
  		LIST_HEAD_INIT(security_hook_heads.inode_listsecurity),
  	.inode_getsecid =
  		LIST_HEAD_INIT(security_hook_heads.inode_getsecid),
@@ -134,3 +135,6 @@ index 46f405c..e33c5d5 100644
  	.file_permission =
  		LIST_HEAD_INIT(security_hook_heads.file_permission),
  	.file_alloc_security =
+-- 
+2.8.2
+

--- a/build/docker/kurma-kernel/patches/0003-overlayfs-use-copy-up-security-hooks.patch
+++ b/build/docker/kurma-kernel/patches/0003-overlayfs-use-copy-up-security-hooks.patch
@@ -1,3 +1,4 @@
+From 4eac8c9deb0ffddf8d71b6783675087a4ee6b436 Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Tue, 16 Jun 2015 14:14:31 +0100
 Subject: [PATCH] Overlayfs: Use copy-up security hooks
@@ -7,27 +8,30 @@ the security on a newly created copy and to filter the xattrs copied to that
 file copy.
 
 Signed-off-by: David Howells <dhowells@redhat.com>
+---
+ fs/overlayfs/copy_up.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
 
 diff --git a/fs/overlayfs/copy_up.c b/fs/overlayfs/copy_up.c
-index eff6319..c01cad6 100644
+index cc514da..a181c7c 100644
 --- a/fs/overlayfs/copy_up.c
 +++ b/fs/overlayfs/copy_up.c
-@@ -71,6 +71,14 @@ retry:
+@@ -102,6 +102,14 @@ retry:
+ 			value_size = size;
  			goto retry;
  		}
- 
 +		error = security_inode_copy_up_xattr(old, new,
 +						     name, value, &size);
 +		if (error < 0)
-+			goto out;
++			break;
 +		if (error == 1) {
 +			error = 0;
 +			continue; /* Discard */
 +		}
+ 
  		error = vfs_setxattr(new, name, value, size, 0);
  		if (error)
- 			break;
-@@ -233,6 +241,10 @@ static int ovl_copy_up_locked(struct dentry *workdir, struct dentry *upperdir,
+@@ -265,6 +273,10 @@ static int ovl_copy_up_locked(struct dentry *workdir, struct dentry *upperdir,
  	if (err)
  		goto out2;
  
@@ -37,4 +41,7 @@ index eff6319..c01cad6 100644
 +
  	if (S_ISREG(stat->mode)) {
  		struct path upperpath;
- 		ovl_path_upper(dentry, &upperpath);
+ 
+-- 
+2.8.2
+

--- a/build/docker/kurma-stage4/build.sh
+++ b/build/docker/kurma-stage4/build.sh
@@ -44,7 +44,7 @@ echo "=sys-boot/syslinux-4.07-r1" >> /etc/portage/package.unmask
 emerge \
     =kurmaos-base/vboot_reference-2.1.0 \
     =app-emulation/open-vm-tools-9.10.0 \
-    =dev-lang/go-1.6.1 \
+    =dev-lang/go-1.6.2 \
     =sys-boot/grub-2.02_beta2_p20151217-r1 \
     =sys-boot/syslinux-4.07-r1
 


### PR DESCRIPTION
Updates the base build image to use Go 1.6.2.

Updates the kernel image to use the 4.6.2 kernel.

FYI PR