### PR TITLE
packer: Add build scripts for Debian.

### DIFF
--- a/build/packer/README.md
+++ b/build/packer/README.md
@@ -8,5 +8,6 @@ running Kurma's integration test suite.
 Following builds are currently defined:
 
 * `centos`: Used to build images for CentOS 7.2.
+* `debian`: Used to build images for Debian jessie/stretch.
 * `fedora`: Used to build images for Fedora 21 and 22.
 * `ubuntu`: Used to build images for Ubuntu 12.04, 14.04, and 15.10.

--- a/build/packer/debian/scripts/01_packages.sh
+++ b/build/packer/debian/scripts/01_packages.sh
@@ -1,0 +1,20 @@
+# Abort on error
+set -e -x
+
+# Sleep to ensure cloud-init has populated the apt sources and written them
+# before we continue. Otherwise, can get odd behavior.
+sleep 60
+
+# Update packages
+apt-get --yes --force-yes update
+
+# http://askubuntu.com/questions/146921/how-do-i-apt-get-y-dist-upgrade-without-a-grub-config-prompt
+# Core problem: post-install scripts don't care that we told apt-get --yes/--force-yes
+DEBIAN_FRONTEND=noninteractive
+UCF_FORCE_CONFFNEW=yes
+export DEBIAN_FRONTEND UCF_FORCE_CONFFNEW
+ucf --purge /boot/grub/menu.lst
+apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy dist-upgrade
+
+# Some needed apps/libraries
+apt-get -y install git libcap2 rsync

--- a/build/packer/debian/scripts/02_install_ruby.sh
+++ b/build/packer/debian/scripts/02_install_ruby.sh
@@ -1,0 +1,76 @@
+# Abort on error
+set -e -x
+
+# We use checksums even when the value is just one we derive, which doesn't
+# prove untampered from maintainer, but proves no corruption in download and
+# that the code is the _same_ as the version we saw.
+apv_yaml=0.1.6
+aps_yaml='7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749' # per manual download
+apv_ruby=2.2.4
+apsubdir_ruby=2.2
+aps_ruby='b6eff568b48e0fda76e5a36333175df049b204e91217aa32a65153cc0cdcb761'
+ # ruby checksum from https://www.ruby-lang.org/en/downloads/
+ # be sure to get the checksum for the right compression format
+apv_rubygems=2.6.1
+aps_rubygems='c9c4d1a8367a1c05bc568fa0eb5c830974d0f328dd73827cc129c0905aae1f4f'  # per manual download
+
+apt-get -y install build-essential libreadline-gplv2-dev zlib1g-dev libssl-dev
+
+download() {
+	local base="$1" fn="$2" cksum_want="$3"
+	wget "$base/$fn"
+	have=$(openssl sha -r -sha256 < "$fn" | cut -d ' ' -f 1)
+	if [ ".$have" != ".$cksum_want" ]; then
+		echo >&2 "CHECKSUM MISMATCH FOR FILE $fn"
+		echo >&2 "    Expected: $cksum_want"
+		echo >&2 "         Got: $have"
+		exit 1
+	fi
+}
+
+cd /tmp
+
+# Install Ruby from source in /opt so that users of Vagrant
+# can install their own Rubies using packages or however.
+download http://pyyaml.org/download/libyaml yaml-${apv_yaml}.tar.gz $aps_yaml
+tar xzf yaml-${apv_yaml}.tar.gz
+cd yaml-${apv_yaml}
+YAMLDIR=`pwd`
+./configure --disable-shared --with-pic
+make
+cd ..
+
+# build ruby
+download http://cache.ruby-lang.org/pub/ruby/$apsubdir_ruby ruby-${apv_ruby}.tar.gz $aps_ruby
+tar xzf ruby-${apv_ruby}.tar.gz
+cd ruby-${apv_ruby}
+OLDLD=$LDFLAGS
+OLDCPP=$CPPFLAGS
+export LDFLAGS="-L$YAMLDIR/src/.libs $LDFLAGS"
+export CPPFLAGS="-I$YAMLDIR/include $CPPFLAGS"
+./configure --prefix=/opt/ruby --enable-shared --disable-install-doc
+make
+make install
+export LDFLAGS=$OLDLD
+export CPPFLAGS=$OLDCPP
+cd ..
+rm -rf yaml-${apv_yaml} yaml-${apv_yaml}.tar.gz ruby-${apv_ruby} ruby-${apv_ruby}.tar.gz
+
+# Install rubygems
+download http://production.cf.rubygems.org/rubygems rubygems-${apv_rubygems}.tgz $aps_rubygems
+tar xzf rubygems-${apv_rubygems}.tgz
+cd rubygems-${apv_rubygems}
+/opt/ruby/bin/ruby setup.rb
+cd ..
+rm -rf rubygems-${apv_rubygems} rubygems-${apv_rubygems}.tgz
+
+# install bundler
+/opt/ruby/bin/gem install bundler -v 1.11.2 --no-ri --no-rdoc
+
+# Symlinks
+ln -s /opt/ruby/bin/ruby /usr/local/bin/ruby
+ln -s /opt/ruby/bin/gem /usr/local/bin/gem
+ln -s /opt/ruby/bin/bundle /usr/local/bin/bundle
+
+# cleanup
+apt-get -y remove build-essential libreadline-gplv2-dev

--- a/build/packer/debian/scripts/03_s3cmd.sh
+++ b/build/packer/debian/scripts/03_s3cmd.sh
@@ -1,0 +1,9 @@
+set -e -x
+
+apt-get -y install python-setuptools
+
+cd /tmp
+wget https://github.com/s3tools/s3cmd/releases/download/v1.6.1/s3cmd-1.6.1.tar.gz
+tar xzvf s3cmd-1.6.1.tar.gz
+cd s3cmd-1.6.1
+python setup.py install

--- a/build/packer/debian/scripts/99_cleanup.sh
+++ b/build/packer/debian/scripts/99_cleanup.sh
@@ -1,0 +1,26 @@
+#
+# cleanup
+#
+
+# remove unnecessary apt items
+apt-get -y autoremove
+apt-get clean
+
+# remote other apt items
+rm -f /var/cache/apt/archives/*.deb
+rm -f /var/cache/apt/*cache.bin
+rm -rf /var/lib/apt/lists
+mkdir /var/lib/apt/lists
+mkdir /var/lib/apt/lists/partial
+
+# Removing leftover leases and persistent rules
+echo "cleaning up dhcp leases"
+rm /var/lib/dhcp/*
+
+# Make sure Udev doesn't block our network
+# http://6.ptmc.org/?p=164
+echo "cleaning up udev rules"
+rm -f /etc/udev/rules.d/70-persistent-net.rules
+mkdir /etc/udev/rules.d/70-persistent-net.rules
+rm -rf /dev/.udev/
+rm -f /lib/udev/rules.d/75-persistent-net-generator.rules

--- a/build/packer/debian/template.json
+++ b/build/packer/debian/template.json
@@ -1,0 +1,40 @@
+{
+  "variables": {
+    "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "source_ami": "{{env `SOURCE_AMI`}}",
+    "source_release": "{{env `SOURCE_RELEASE`}}"
+  },
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/01_packages.sh",
+        "scripts/02_install_ruby.sh",
+        "scripts/03_s3cmd.sh",
+        "scripts/99_cleanup.sh"
+      ],
+      "execute_command": "{{ .Vars }} sudo -E bash '{{.Path}}'"
+    }
+  ],
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{user `aws_access_key_id`}}",
+      "secret_key": "{{user `aws_secret_access_key`}}",
+      "source_ami": "{{user `source_ami`}}",
+      "region": "us-west-2",
+      "subnet_id": "subnet-e1aa5385",
+      "security_group_id": "sg-9a26a6fd",
+      "instance_type": "m3.medium",
+      "associate_public_ip_address": true,
+      "ssh_private_ip": true,
+      "ssh_username": "admin",
+      "ami_groups": [ "all" ],
+      "ami_name": "kurma-tests-debian-{{user `source_release`}}-{{timestamp}}",
+      "tags": {
+        "Name": "kurma-tests-debian-{{user `source_release`}}-{{timestamp}}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds packer build scripts for Debian. These should work against
Debian 8.0/jessie as well as the upcoming 9.0/stretch.

FYI PR, merging after the test posts to the build. Only adds packer definitions, current master is green on Debian.