### PR TITLE
packer: Update CentOS to not require tty for sudo

### DIFF
--- a/build/packer/centos/scripts/04_ssh.sh
+++ b/build/packer/centos/scripts/04_ssh.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e -x
+
+echo 'Defaults:centos !requiretty' > /etc/sudoers.d/999-vagrant-cloud-init-requiretty
+chmod 440 /etc/sudoers.d/999-vagrant-cloud-init-requiretty
+
+sed -i'.bk' -e 's/^\(Defaults\s\+requiretty\)/# \1/' /etc/sudoers

--- a/build/packer/centos/template.json
+++ b/build/packer/centos/template.json
@@ -12,6 +12,7 @@
         "scripts/01_packages.sh",
         "scripts/02_install_ruby.sh",
         "scripts/03_s3cmd.sh",
+        "scripts/04_ssh.sh",
         "scripts/99_cleanup.sh"
       ],
       "execute_command": "{{ .Vars }} sudo -E bash '{{.Path}}'"


### PR DESCRIPTION
Updates the CentOS build scripts to not require a tty for sudo
access. This causes issues with vagrant-aws and rsyncing, even with the
Vagrantfile specified to use a tty.

FYI PR