### PR TITLE
discovery: override the http.Client transport in the discovery package.

### DIFF
--- a/pkg/aciremote/remote.go
+++ b/pkg/aciremote/remote.go
@@ -29,6 +29,11 @@ var (
 	}
 )
 
+func init() {
+	discovery.Client.Transport = &http.Transport{}
+	discovery.ClientInsecureTLS.Transport = &http.Transport{}
+}
+
 // RetrieveImage can be used to retrieve a remote image, and optionally discover
 // an image based on the App Container Image Discovery specification. Supports
 // handling local images as well as


### PR DESCRIPTION
@krobertson @alextoombs 

The transport defined in that package has a timeout of 5 seconds, which was causing
package discovery to time out on my VM which has a slow network.