### PR TITLE
stager: Add support for readOnlyRootFS on Pod Manifest

### DIFF
--- a/stager/container/core/util.go
+++ b/stager/container/core/util.go
@@ -150,6 +150,7 @@ func (cs *containerSetup) getAppContainerConfig(runtimeApp schema.RuntimeApp) (*
 		ParentDeathSignal: int(syscall.SIGTERM),
 		Rootfs:            filepath.Join("/apps", name),
 		RootPropagation:   syscall.MS_PRIVATE,
+		Readonlyfs:        runtimeApp.ReadOnlyRootFS,
 		Namespaces: []configs.Namespace{
 			{Type: configs.NEWNS},
 			{Type: configs.NEWIPC, Path: fmt.Sprintf("/proc/%d/ns/ipc", initPid)},


### PR DESCRIPTION
This adds support for the readOnlyRootFS flag on a pod to configure the
application's root to be read-only. This parameter was added in the
0.8.1 spec.

FYI PR