### PR TITLE
makefile: Updated release handling to build tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,12 +211,26 @@ endif
 release-to-resources-linux:
 	@mkdir -p ./resources
 	@cp ./bin/console.aci ./bin/kurma-api.aci ./bin/kurma-cli \
-		./bin/kurmaos-openstack.zip ./bin/kurmaos-virtualbox.zip \
-		./bin/kurmaos-vmware.zip ./bin/kurmad \
-		./bin/kurma-upgrader.aci ./bin/stager-container.aci ./resources/
+		./bin/kurmad ./bin/stager-container.aci ./LICENSE ./resources/
+	@cp ./build/release/example-kurmad.yml ./resources/kurmad.yml
+	@cp ./bin/kurma-upgrader.aci ./resources/kurma-upgrader-$(VERSION).aci
+	@cp ./bin/kurmaos-openstack.zip ./resources/kurmaos-openstack-$(VERSION).zip
+	@cp ./bin/kurmaos-virtualbox.zip ./resources/kurmaos-virtualbox-$(VERSION).zip
+	@cp ./bin/kurmaos-vmware.zip ./resources/kurmaos-vmware-$(VERSION).zip
+	@tar -czf ./resources/kurma-cli-$(VERSION)-linux-amd64.tar.gz -C ./resources LICENSE kurma-cli
+	@tar -cf ./resources/kurmad-$(VERSION)-linux-amd64.tar -C ./resources LICENSE kurmad kurmad.yml \
+		console.aci stager-container.aci
+	@tar --append -f ./resources/kurmad-$(VERSION)-linux-amd64.tar -C ./bin busybox.aci cni-netplugin.aci
+	@gzip -f ./resources/kurmad-$(VERSION)-linux-amd64.tar
+	@zip -g -j ./resources/kurmaos-openstack-$(VERSION).zip ./resources/LICENSE
+	@zip -g -j ./resources/kurmaos-virtualbox-$(VERSION).zip ./resources/LICENSE
+	@zip -g -j ./resources/kurmaos-vmware-$(VERSION).zip ./resources/LICENSE
+	@rm ./resources/LICENSE ./resources/kurmad.yml
 release-to-resources-darwin:
 	@mkdir -p ./resources
-	@cp ./bin/kurma-cli ./resources/
+	@cp ./bin/kurma-cli ./LICENSE ./resources/
+	@tar -czf ./resources/kurma-cli-$(VERSION)-darwin-amd64.tar.gz -C ./resources LICENSE kurma-cli
+	@rm ./resources/LICENSE
 
 
 #

--- a/build/release/README.md
+++ b/build/release/README.md
@@ -1,0 +1,4 @@
+# Release Artifacts
+
+This directory contains various artifacts that are included in final release
+archives.

--- a/build/release/example-kurmad.yml
+++ b/build/release/example-kurmad.yml
@@ -1,0 +1,31 @@
+---
+
+##
+## Example kurmad configuration
+##
+## Note the file paths included are all using the local directory. It assumes
+## this contains all of the files from the release tarball.
+
+socketPath: ./kurma.sock
+socketPermissions: 0666
+parentCgroupName: kurma
+podsDirectory: ./pods
+imagesDirectory: ./images
+volumesDirectory: ./volumes
+defaultStagerImage: file://stager-container.aci
+
+prefetchImages:
+- file://busybox.aci
+
+podNetworks:
+- name: bridge
+  aci: "file://cni-netplugin.aci"
+  default: true
+  containerInterface: "veth+{{shortuuid}}"
+  type: bridge
+  bridge: bridge0
+  isDefaultGateway: true
+  ipMasq: true
+  ipam:
+    type: host-local
+    subnet: 10.220.0.0/16

--- a/cmd/kurmad.go
+++ b/cmd/kurmad.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	var configFile string
-	flag.StringVar(&configFile, "configFile", "kurmad.yaml", "Path to the kurma configuration file")
+	flag.StringVar(&configFile, "configFile", "kurmad.yml", "Path to the kurma configuration file")
 	flag.Parse()
 
 	logray.AddDefaultOutput("stdout://", logray.ALL)


### PR DESCRIPTION
This updates the release make tasks to generate releasable
tarballs. These include the license file as well as all the necessary
dependencies and example configuration, such as for the main kurmad
release.

Previously, the release just generated the set of binaries just loosely
in a directory, but not a single file that could be downloaded,
extracted, and utilized.

FYI PR