### PR TITLE
kurmaos updates for kernel 4.6.3 and configuration tweaks.

### DIFF
--- a/build/docker/kurma-kernel/build.sh
+++ b/build/docker/kurma-kernel/build.sh
@@ -12,8 +12,8 @@ emerge --sync
 emerge sys-kernel/linux-firmware
 
 # allow the proper kernel version
-echo '=sys-kernel/vanilla-sources-4.6.2 ~amd64' >> /etc/portage/package.accept_keywords
-emerge =sys-kernel/vanilla-sources-4.6.2
+echo '=sys-kernel/vanilla-sources-4.6.3 ~amd64' >> /etc/portage/package.accept_keywords
+emerge =sys-kernel/vanilla-sources-4.6.3
 mv /tmp/kernel.defconfig /usr/src/linux/.config
 
 cd /usr/src/linux

--- a/build/kurma-init/kurma.yml
+++ b/build/kurma-init/kurma.yml
@@ -14,6 +14,7 @@ modules:
   - br_netfilter
   - nf_conntrack_ipv4
   - xt_addrtype
+  - xt_comment
   - ipt_MASQUERADE
   - xt_conntrack
   - iptable_nat
@@ -50,12 +51,11 @@ podNetworks:
     containerInterface: "veth+{{shortuuid}}"
     type: bridge
     bridge: bridge0
-    isGateway: true
+    isDefaultGateway: true
     ipMasq: true
     ipam:
       type: host-local
-      subnet: 10.220.0.0/16
-      routes: [ { dst: 0.0.0.0/0 } ]
+      subnet: 10.230.0.0/16
 
 # Initial pods to launch on startup
 initialPods:


### PR DESCRIPTION
 This updates the kurma-kernel docker image to use the 4.6.3 kernel.

This also updates some default configuration in kurmaOS to match latest
CNI, as well as ensuring the comments module for iptables is loaded in
at boot.

FYI PR