### PR TITLE
podmanager: Fix an issue with resolv.conf when using an isolated network

### DIFF
--- a/pkg/networkmanager/driver.go
+++ b/pkg/networkmanager/driver.go
@@ -138,6 +138,8 @@ func (d *networkDriver) call(exec string, args []string, val interface{}) error 
 		return werr
 	}
 
+	d.manager.log.Tracef("Called driver %s %s, exit %d: %q", d.config.Name, exec, exitCode, string(outBytes))
+
 	// if exit code wasn't 0, return stderr value as the error
 	if exitCode == 0 {
 		if val != nil {

--- a/pkg/podmanager/pod_operations.go
+++ b/pkg/podmanager/pod_operations.go
@@ -195,7 +195,9 @@ func (pod *Pod) startingResolvConf() error {
 
 	// Check to see if a DNS configuration was provided
 	for _, result := range pod.networkResults {
-		if result.DNS != nil {
+		// FIXME: CNI always returns a "DNS" field with an empty value. We'll just
+		// iterate its fields and see if everything is empty.
+		if result.DNS != nil && !isBlankDNS(result.DNS) {
 			dns = result.DNS
 			break
 		}

--- a/testing/integration/lib/kurma/api_client.rb
+++ b/testing/integration/lib/kurma/api_client.rb
@@ -22,4 +22,8 @@ class Kurma::ApiClient
   def list_pods
     @client.invoke("Pods.List", [])
   end
+
+  def get_pod(uuid)
+    @client.invoke("Pods.Get", [uuid])
+  end
 end

--- a/testing/integration/spec/networking_spec.rb
+++ b/testing/integration/spec/networking_spec.rb
@@ -2,14 +2,41 @@
 require 'spec_helper'
 
 RSpec.describe "Container networking" do
-  it "should create a resolv.conf for containers" do
-    output = cli.run!("create docker://busybox --name busybox --net=host /bin/sleep 60")
-    uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
-    expect(uuid).not_to be_nil
-    @cleanup << "stop #{uuid}"
+  context "with host networking" do
+    it "should create a resolv.conf for containers" do
+      output = cli.run!("create docker://busybox --name busybox --net=host /bin/sleep 60")
+      uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
+      expect(uuid).not_to be_nil
+      @cleanup << "stop #{uuid}"
 
-    output = cli.run!("enter #{uuid} busybox", "cat /etc/resolv.conf", "exit")
-    output.gsub!("\r", "") # trim carriage returns
-    expect(output).to match(/^nameserver \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)
+      # validate it has a resolv.conf with a nameserver entry and a valid IP
+      output = cli.run!("enter #{uuid} busybox", "cat /etc/resolv.conf", "exit")
+      output.gsub!("\r", "") # trim carriage returns
+      expect(output).to match(/^nameserver \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)
+    end
+  end
+
+  context "with isolated networking" do
+    context "bridge" do
+      it "should create a resolv.conf for containers" do
+        output = cli.run!("create docker://busybox --name busybox --net=bridge /bin/sleep 60")
+        uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
+        expect(uuid).not_to be_nil
+        @cleanup << "stop #{uuid}"
+
+        # retrieve the pod object and validate it has a network entry and
+        # matching an IP in the bridge network's range
+        pod = api.get_pod(uuid)
+        expect(pod).to be_kind_of(Hash)
+        puts pod["pod"]["networks"].inspect
+        expect(pod["pod"]["networks"].size).to be(1)
+        expect(pod["pod"]["networks"][0]["ip4"]["ip"]).to match(/^10\.220\.0\.\d{1,3}\/16/)
+
+        # validate it has a resolv.conf with a nameserver entry and a valid IP
+        output = cli.run!("enter #{uuid} busybox", "cat /etc/resolv.conf", "exit")
+        output.gsub!("\r", "") # trim carriage returns
+        expect(output).to match(/^nameserver \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)
+      end
+    end
   end
 end


### PR DESCRIPTION
The CNI modules will default to returning a result including `"dns:"{}`,
which will cause the DNS property on the result ot be populated with an
empty object rather than nil.

This adds a work around which iterates over all of the DNS object's
fields and if all of them are blank/empty, it will use the host's
resolv.conf settings.

This changes some of the system tests so that the resolv.conf check is
done with both host networking and isolated networking, currently using
the default included bridge network. In time, will likely have multiple
networks defined in the testing config for testing more networking
modes/settings.

@wallyqs @jpoler 