### PR TITLE
cni: Ensure modules are available for iptables

### DIFF
--- a/build/aci/cni-netplugin/build.sh
+++ b/build/aci/cni-netplugin/build.sh
@@ -37,5 +37,10 @@ cp add.sh $dir/opt/network/add
 cp del.sh $dir/opt/network/del
 chmod a+x $dir/opt/network/*
 
+# create a symlink so the console can access kernel modules from the host
+mkdir -p $dir/lib
+ln -s /host/proc/1/root/lib/firmware $dir/lib/firmware
+ln -s /host/proc/1/root/lib/modules $dir/lib/modules
+
 # generate the aci
 go run ../build.go -manifest ./manifest.yaml -root $dir -version $version -output $BASE_PATH/$1

--- a/build/aci/cni-netplugin/manifest.yaml
+++ b/build/aci/cni-netplugin/manifest.yaml
@@ -13,5 +13,7 @@ app:
   isolators:
   - name: os/linux/privileged
     value: true
+  - name: host/privileged
+    value: true
 dependencies:
   - imageName: kurma.io/busybox


### PR DESCRIPTION
It may be necessary for iptables to attempt to load some kernel modules
if they aren't already present. To help this function, adding the host
privilege isolator to the CNI image's manifest and the necessary
symlinks.

FYI PR, needed for #92 