### PR TITLE
stager/api: Add support for returning the exit code on run calls

### DIFF
--- a/pkg/apiclient/types.go
+++ b/pkg/apiclient/types.go
@@ -45,6 +45,11 @@ type ContainerEnterRequest struct {
 	App     kschema.RunApp `json:"app"`
 }
 
+type ContainerEnterResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
 type ImageListResponse struct {
 	Images []*Image `json:"images"`
 }

--- a/stager/container/main.go
+++ b/stager/container/main.go
@@ -23,7 +23,9 @@ func init() {
 		runtime.LockOSThread()
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "%s\n\r", err)
+			os.Exit(1)
+			return
 		}
 		panic("--this line should have never been executed, congratulations--")
 	}
@@ -44,7 +46,7 @@ func main() {
 	}
 
 	if err := execFunc(); err != nil {
-		fmt.Fprintf(os.Stderr, "ERR: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%s\n\r", err)
 		os.Exit(1)
 	}
 }

--- a/testing/integration/spec/create_spec.rb
+++ b/testing/integration/spec/create_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe "CLI create" do
     output.gsub!("\r", "") # trim carriage returns
     expect(output).to match("whoami\nroot")
   end
+
+  it "should enter a container and return the status code on exit" do
+    output = cli.run!("create docker://busybox --name busybox --net=host /bin/sleep 60")
+    uuid = output.scan(/Launched pod ([\w-]+)/).flatten.first
+    expect(uuid).not_to be_nil
+    @cleanup << "stop #{uuid}"
+
+    _, _, status = cli.run("enter #{uuid} busybox", "exit 45")
+    expect(status.exitstatus).to be(45)
+  end
 end


### PR DESCRIPTION
This updates the container stager to properly return the exit code from
the process it was executing. Previously, the caller was always getting
a zero exit code rather than the actual one.

This also adds support for returning the exit code on container enter
requests over the API/CLI. This way, the CLI will exit with the same
code as the process it was running in the container.

An integration test has been added to test the exit code handling
propagating.

@alextoombs @wallyqs @jpoler 