### PR TITLE
Tweaks to logging around Kurma managers

### DIFF
--- a/cmd/kurmad.go
+++ b/cmd/kurmad.go
@@ -7,6 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"runtime"
 
@@ -14,12 +15,23 @@ import (
 	"github.com/apcera/logray"
 )
 
+const (
+	formatString = "%color:class%%year%-%month%-%day% %hour%:%minute%:%second%.%nanosecond% %tzoffset% %tz% [%class% pid=%pid% pod='%field:pod%' source='%sourcefile%:%sourceline%']%color:default% %message%"
+)
+
 func main() {
 	var configFile string
 	flag.StringVar(&configFile, "configFile", "kurmad.yml", "Path to the kurma configuration file")
 	flag.Parse()
 
-	logray.AddDefaultOutput("stdout://", logray.ALL)
+	u := url.URL{
+		Scheme: "stdout",
+		RawQuery: url.Values(map[string][]string{
+			"format": []string{formatString},
+		}).Encode(),
+	}
+
+	logray.AddDefaultOutput(u.String(), logray.ALL)
 
 	if err := kurmad.Run(configFile); err != nil {
 		fmt.Fprintf(os.Stderr, "Failure running process: %v\n", err)

--- a/kurmad/runner.go
+++ b/kurmad/runner.go
@@ -262,7 +262,9 @@ func (r *runner) startInitialPods() error {
 			r.log.Errorf("Failed to launch pod %q: %v", name, err)
 			continue
 		}
-		r.log.Infof("Launched pod %q.", pod.Name())
+		l := r.log.Clone()
+		l.SetField("pod", pod.UUID())
+		l.Infof("Launched initial pod %q.", pod.Name())
 	}
 	return nil
 }

--- a/pkg/podmanager/manager.go
+++ b/pkg/podmanager/manager.go
@@ -203,7 +203,7 @@ func (manager *Manager) Create(name string, manifest *schema.PodManifest, option
 	manager.podsLock.Unlock()
 
 	// begin the startup sequence
-	pod.log.Debugf("Launching pod %s", pod.uuid)
+	pod.log.Debugf("Launching pod %q", pod.name)
 	pod.start()
 
 	return pod, nil


### PR DESCRIPTION
Changes format of logging string for kurmad, sets the pod field among other minor logging related changes.

<img width="1058" alt="sample-logging" src="https://cloud.githubusercontent.com/assets/26195/16509441/a84fb35a-3ef1-11e6-9248-c2ce9735ced7.png">
@krobertson 