### PR TITLE
Add docker client to kurma-stage4 image.

### DIFF
--- a/build/docker/kurma-stage4/build.sh
+++ b/build/docker/kurma-stage4/build.sh
@@ -71,6 +71,10 @@ emerge sys-apps/util-linux
 # install acbuild, for creating aci images
 curl -L https://github.com/appc/acbuild/releases/download/v0.2.2/acbuild.tar.gz | tar xzv -C /usr/bin
 
+# install docker client, necessary for building deb and rpm packages.
+wget "https://get.docker.com/builds/Linux/x86_64/docker-1.10.2" -O /usr/bin/docker
+chmod +x /usr/bin/docker
+
 # cleanup
 rm -rf /usr/portage
 rm -rf /var/tmp

--- a/build/docker/kurma-stage4/build.sh
+++ b/build/docker/kurma-stage4/build.sh
@@ -72,7 +72,7 @@ emerge sys-apps/util-linux
 curl -L https://github.com/appc/acbuild/releases/download/v0.2.2/acbuild.tar.gz | tar xzv -C /usr/bin
 
 # install docker client, necessary for building deb and rpm packages.
-wget "https://get.docker.com/builds/Linux/x86_64/docker-1.10.2" -O /usr/bin/docker
+curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.10.2" -o /usr/bin/docker
 chmod +x /usr/bin/docker
 
 # cleanup


### PR DESCRIPTION
This will allow us to run docker containers from within the kurma-stage4 image (which is used for running build steps in CI).

The binding mounting of the docker socket will occur on container creation and had already been added in the CI config.