### PR TITLE
packer: Specify delete_on_termination in packer templates

### DIFF
--- a/build/packer/centos/template.json
+++ b/build/packer/centos/template.json
@@ -29,6 +29,7 @@
       "security_group_id": "sg-9a26a6fd",
       "instance_type": "m3.medium",
       "associate_public_ip_address": true,
+      "delete_on_termination": true,
       "ssh_private_ip": true,
       "ssh_username": "centos",
       "ssh_pty": true,

--- a/build/packer/debian/template.json
+++ b/build/packer/debian/template.json
@@ -28,6 +28,7 @@
       "security_group_id": "sg-9a26a6fd",
       "instance_type": "m3.medium",
       "associate_public_ip_address": true,
+      "delete_on_termination": true,
       "ssh_private_ip": true,
       "ssh_username": "admin",
       "ami_groups": [ "all" ],

--- a/build/packer/fedora/template.json
+++ b/build/packer/fedora/template.json
@@ -28,6 +28,7 @@
       "security_group_id": "sg-9a26a6fd",
       "instance_type": "m3.medium",
       "associate_public_ip_address": true,
+      "delete_on_termination": true,
       "ssh_private_ip": true,
       "ssh_username": "fedora",
       "ami_groups": [ "all" ],

--- a/build/packer/ubuntu/template.json
+++ b/build/packer/ubuntu/template.json
@@ -28,6 +28,7 @@
       "security_group_id": "sg-9a26a6fd",
       "instance_type": "m3.medium",
       "associate_public_ip_address": true,
+      "delete_on_termination": true,
       "ssh_private_ip": true,
       "ssh_username": "ubuntu",
       "ami_groups": [ "all" ],


### PR DESCRIPTION
This adds explicitly setting delete_on_termination to all the packer
templates. Without this specified, it was copying the setting from the
source image. On all of the source images except for CentOS, this was
enabled by default.

However, without it enabled on CentOS, CI integration test runs were
leaving behind volumes on AWS for each run.

Explicitly setting this will ensure it is always enabled.

FYI PR