### PR TITLE
testing: Enable the debug flag in integration tests

### DIFF
--- a/testing/integration/lib/kurma/server.rb
+++ b/testing/integration/lib/kurma/server.rb
@@ -21,6 +21,7 @@ class Kurma::Server
     cfgfile = File.join(tmppath, "kurmad.yml")
     File.open(cfgfile, "w") do |f|
       f.puts %Q{---
+debug: true
 socketPath: #{tmppath}/kurma.sock
 socketPermissions: 0666
 


### PR DESCRIPTION
This enables the debug flag in integration tests to have the stager
output written to kurmad's log. This will hope expose messages from the
stagers inline with the kurmad process.

FYI PR, will merge on green... cc @wallyqs 