### PR TITLE
build: Don't include the kurma-upgrader ACI in deb/rpm packages

### DIFF
--- a/build/docker/deb/make-deb-package.sh
+++ b/build/docker/deb/make-deb-package.sh
@@ -16,7 +16,6 @@ cp ./bin/kurma-cli ./bin/kurmad $PACKAGE_DIR/usr/bin
 cp ./build/release/base-config.yml $PACKAGE_DIR/etc/kurmad/config.yml
 cp ./bin/kurma-api.aci \
 	./bin/console.aci \
-	./bin/kurma-upgrader.aci \
 	./bin/stager-container.aci \
 	./bin/busybox.aci \
 	./bin/cni-netplugin.aci \

--- a/build/docker/rpm/make-rpm-package.sh
+++ b/build/docker/rpm/make-rpm-package.sh
@@ -17,7 +17,6 @@ cp ./bin/kurma-cli ./bin/kurmad $PACKAGE_DIR/usr/bin
 cp ./build/release/base-config.yml $PACKAGE_DIR/etc/kurmad/config.yml
 cp ./bin/kurma-api.aci \
 	./bin/console.aci \
-	./bin/kurma-upgrader.aci \
 	./bin/stager-container.aci \
 	./bin/busybox.aci \
 	./bin/cni-netplugin.aci \


### PR DESCRIPTION
This removes adding the kurma-upgrader ACI image in the deb/rpm package
builds. This image is used to upgrade a kurmaOS host, so it is not
relevant to the kurmad packages. It also greatly bloated the size of the
packages.

Fixes #110 
FYI PR @jpoler 