### PR TITLE
stager: Fix issue with init handling returns from signal handlers

### DIFF
--- a/build/local-kurmad.yml
+++ b/build/local-kurmad.yml
@@ -7,6 +7,7 @@
 # Note the paths here are intentional, as the running of the daemon is setup
 # through `run.sh`
 
+debug: true
 socketPath: ./kurma.sock
 socketPermissions: 0666
 parentCgroupName: kurma

--- a/stager/container/init/init.c
+++ b/stager/container/init/init.c
@@ -10,6 +10,7 @@
 
 // This function is called when a SIGCHLD signal is received.
 static void signal_sigchld(int sig) {
+	while (waitpid(-1, NULL, WNOHANG) > 0) ;
 	return;
 }
 
@@ -39,7 +40,7 @@ static void setup_signal_handler(void)
 		error(1, errno, "Error in sigaction() for sigchld");
 	}
 
-	// Set up sigterm and sigint.
+	// Set up sigterm.
 	sigterm_handler.sa_handler = signal_sigterm;
 	sigterm_handler.sa_flags = 0;
 	if (sigemptyset(&sigterm_handler.sa_mask)) {
@@ -57,7 +58,8 @@ int main(int argc, char **argv) {
 	// Configure the signal handler.
 	setup_signal_handler();
 
-	// Just wait...
-	pause();
+	// Just wait. Loop it with checking EINTR to handle returning from a signal
+	// handler.
+	while(pause() == -1 && errno == EINTR) ;
 	exit(0);
 }


### PR DESCRIPTION
This fixes an issue where the init process wasn't properly handling the
return from a signal handler. The pause(2) documentation clearly states
the pause call only returns when the process was interrupted by a signal
and the signal handler has finished running.

In this case, pause will verify it returned due to a signal handler and
re-run pause.

This also adds a loop to waitpid in the sigchld signal handler to
properly reap the pid.

Also updated the local configuration file used with `make run` to enable
debugging.

A follow up PR will be posted to fix the "run" call returning
immediately with a forked process, and at that time I'll add an
integration test around the behavior.

@wallyqs @mbhinder 