### PR TITLE
cli: Update kurma-cli to search multiple locations for the kurmad socket

### DIFF
--- a/pkg/cli/commands/image_list.go
+++ b/pkg/cli/commands/image_list.go
@@ -44,7 +44,7 @@ func cmdImageList(cmd *cobra.Command, args []string) {
 
 	images, err := cli.GetClient().ListImages()
 	if err != nil {
-		fmt.Printf("Failed to get list of containers: %v", err)
+		fmt.Printf("Failed to get list of containers: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/pkg/cli/commands/list.go
+++ b/pkg/cli/commands/list.go
@@ -34,7 +34,7 @@ func cmdList(cmd *cobra.Command, args []string) {
 
 	pods, err := cli.GetClient().ListPods()
 	if err != nil {
-		fmt.Printf("Failed to get list of pods: %v", err)
+		fmt.Printf("Failed to get list of pods: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/pkg/cli/commands/status.go
+++ b/pkg/cli/commands/status.go
@@ -32,7 +32,7 @@ func cmdStatus(cmd *cobra.Command, args []string) {
 
 	info, err := cli.GetClient().Info()
 	if err != nil {
-		fmt.Printf("Failed to get host status: %v", err)
+		fmt.Printf("Failed to get host status: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This updates kurma-cli to search multiple locations for the default
socket location. Previously, it always searched for
/var/lib/kurma/kurma.sock.

However with the prebuilt deb and rpm packages, they may often be at
/var/run/kurma.sock, more in line with that distro's recommendations or
what not.

It will now search /var/lib/kurma.sock and /var/run/kurma.sock, and go
with whichever one exists.

This also fixes a few locations that were missing newlines around error
messages in the cli.

@wallyqs @mbhinder 