### PR TITLE
build: Ensure last ACIs get version labels at release build time

### DIFF
--- a/build/aci/kurma-api/build.sh
+++ b/build/aci/kurma-api/build.sh
@@ -29,4 +29,7 @@ echo "/lib" > $dir/etc/ld.so.conf
 (cd $dir && ldconfig -r . -C etc/ld.so.cache -f etc/ld.so.conf)
 
 # generate the aci
-go run ../build.go -manifest ./manifest.yaml -root $dir -output $BASE_PATH/$1
+if [ -n "$VERSION" ]; then
+    params="-version $VERSION"
+fi
+go run ../build.go -manifest ./manifest.yaml -root $dir $params -output $BASE_PATH/$1

--- a/build/aci/kurma-stager-container/build.sh
+++ b/build/aci/kurma-stager-container/build.sh
@@ -45,4 +45,7 @@ echo "/lib" > $dir/etc/ld.so.conf
 (cd $dir && ldconfig -r . -C etc/ld.so.cache -f etc/ld.so.conf)
 
 # generate the aci
-go run ../build.go -manifest ./manifest.yaml -root $dir -output $BASE_PATH/$1
+if [ -n "$VERSION" ]; then
+    params="-version $VERSION"
+fi
+go run ../build.go -manifest ./manifest.yaml -root $dir $params -output $BASE_PATH/$1

--- a/build/aci/kurma-upgrader/build.sh
+++ b/build/aci/kurma-upgrader/build.sh
@@ -41,4 +41,7 @@ echo "/lib" > $dir/etc/ld.so.conf
 (cd $dir && ldconfig -r . -C etc/ld.so.cache -f etc/ld.so.conf)
 
 # generate the aci
-go run ../build.go -manifest ./manifest.yaml -root $dir -output $BASE_PATH/$1
+if [ -n "$VERSION" ]; then
+    params="-version $VERSION"
+fi
+go run ../build.go -manifest ./manifest.yaml -root $dir $params -output $BASE_PATH/$1


### PR DESCRIPTION
The kurma-api, kurma-upgrader, and stager-container ACI images were
missing version labels being set at build time.

This ensures the value gets set at build time if there is a VERSION
environment variable.

@wallyqs @alextoombs @mbhinder 

Last thing I noticed when testing the release. This matches what was being done for the console ACI at build time.