### PR TITLE
Update `Pull` to handle multi-layer images

### DIFF
--- a/pkg/cli/commands/create.go
+++ b/pkg/cli/commands/create.go
@@ -54,11 +54,16 @@ func createPodFromFile(file string) (*apiclient.Image, error) {
 			labels[types.ACIdentifier("os")] = "linux"
 			labels[types.ACIdentifier("arch")] = info.Arch
 
-			f, err = image.Fetch(file, labels, true)
+			layers, err := image.Fetch(file, labels, true)
 			if err != nil {
 				fmt.Printf("Failed to retrieve the container image: %v\n", err)
 				os.Exit(1)
 			}
+			if len(layers) != 1 {
+				fmt.Println("Multi-layer images currently not supported")
+				os.Exit(1)
+			}
+			f = layers[0]
 		} else {
 			fmt.Printf("Failed to open the container image: %v\n", err)
 			os.Exit(1)

--- a/pkg/image/fetch_test.go
+++ b/pkg/image/fetch_test.go
@@ -17,11 +17,14 @@ func TestFetch_LocalFile(t *testing.T) {
 
 	uri := "file://" + f.Name()
 
-	reader, err := Fetch(uri, nil, false)
+	readers, err := Fetch(uri, nil, false)
 	if err != nil {
 		t.Fatalf("Expected no error retrieving %s; got %s", uri, err)
 	}
-	reader.Close()
+
+	for _, r := range readers {
+		r.Close()
+	}
 }
 
 func TestFetch_UnsupportedScheme(t *testing.T) {

--- a/pkg/remote/aci/pull.go
+++ b/pkg/remote/aci/pull.go
@@ -42,7 +42,7 @@ func New(insecure bool, labels map[types.ACIdentifier]string) remote.Puller {
 // Pull can be used to retrieve a remote image, and optionally discover
 // an image based on the App Container Image Discovery specification. Callers
 // should close the ReadCloser after reading.
-func (a *aciPuller) Pull(aci string) (io.ReadCloser, error) {
+func (a *aciPuller) Pull(aci string) ([]io.ReadCloser, error) {
 	app, err := discovery.NewAppFromString(aci)
 	if err != nil {
 		return nil, err
@@ -64,13 +64,13 @@ func (a *aciPuller) Pull(aci string) (io.ReadCloser, error) {
 	httpPuller := remotehttp.New()
 
 	for _, ep := range endpoints {
-		r, err := httpPuller.Pull(ep.ACI)
+		readers, err := httpPuller.Pull(ep.ACI)
 		if err != nil {
 			// TODO: log
 			continue
 		}
-		// TODO: verify signature of downloaded ACI.
-		return r, nil
+		// TODO: verify signature of downloaded ACI(s).
+		return readers, nil
 	}
 	return nil, fmt.Errorf("failed to find a valid image for %q", aci)
 }

--- a/pkg/remote/aci/pull_test.go
+++ b/pkg/remote/aci/pull_test.go
@@ -37,11 +37,18 @@ func TestACIPull_InsecureHTTPDiscover(t *testing.T) {
 
 	puller := buildACIPuller(true)
 
-	f, err := puller.Pull(imageName)
+	acis, err := puller.Pull(imageName)
 	if err != nil {
 		t.Fatalf("Failed to pull %q: %s", imageName, err)
 	}
-	f.Close()
+
+	if len(acis) != 1 {
+		t.Fatalf("Expected 1 ACI, got %d", len(acis))
+	}
+
+	for _, a := range acis {
+		a.Close()
+	}
 }
 
 func TestACIPull_SecureHTTPSDiscover(t *testing.T) {

--- a/pkg/remote/docker/pull_test.go
+++ b/pkg/remote/docker/pull_test.go
@@ -38,8 +38,37 @@ func TestDockerPull(t *testing.T) {
 	}
 
 	u.Scheme = "docker"
-	_, err = puller.Pull(u.String())
+	layers, err := puller.Pull(u.String())
 	if err != nil {
 		t.Fatalf("Failed to pull %q: %s", imageURI, err)
+	}
+	if len(layers) != 1 {
+		t.Fatalf("Expected one layer, got %d", len(layers))
+	}
+}
+
+func TestDockerPull_NoSquash(t *testing.T) {
+	puller := New(true)
+
+	dockerImgPuller, ok := puller.(*dockerPuller)
+	if !ok {
+		t.Fatal("Type assertion to dockerPuller failed")
+	}
+
+	dockerImgPuller.squashLayers = false
+
+	imageURI := fmt.Sprintf("%s/library/nats:latest", dockerRegistryURL)
+	u, err := url.Parse(imageURI)
+	if err != nil {
+		t.Fatalf("Failed to parse %q as URL: %s", imageURI, err)
+	}
+
+	u.Scheme = "docker"
+	layers, err := puller.Pull(u.String())
+	if err != nil {
+		t.Fatalf("Failed to pull %q: %s", imageURI, err)
+	}
+	if len(layers) < 2 {
+		t.Fatalf("Expected more than two layers, got %d", len(layers))
 	}
 }

--- a/pkg/remote/http/pull.go
+++ b/pkg/remote/http/pull.go
@@ -33,7 +33,7 @@ func New() remote.Puller {
 
 // Pull fetches a remote image. Callers should close the ReadCloser after
 // reading.
-func (c *client) Pull(imageURI string) (io.ReadCloser, error) {
+func (c *client) Pull(imageURI string) ([]io.ReadCloser, error) {
 	resp, err := c.Client.Get(imageURI)
 	if err != nil {
 		return nil, err
@@ -45,5 +45,5 @@ func (c *client) Pull(imageURI string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("HTTP %d on retrieving %q", resp.StatusCode, imageURI)
 	}
 
-	return resp.Body, nil
+	return []io.ReadCloser{resp.Body}, nil
 }

--- a/pkg/remote/puller.go
+++ b/pkg/remote/puller.go
@@ -8,6 +8,7 @@ import (
 
 // A Puller pulls container images.
 type Puller interface {
-	// Pull fetches an image.
-	Pull(uri string) (io.ReadCloser, error)
+	// Pull fetches images. Multiple layers may be returned depending upon
+	// format and content of requested image.
+	Pull(uri string) ([]io.ReadCloser, error)
 }


### PR DESCRIPTION
Previously, every time we pulled a Docker image, we would squash the layers into a single ACI. We want to be able to eventually re-use common layers across different docker images.

This PR doesn't expose the option to users; it just adds some plumbing.

@krobertson @wallyqs @mbhinder 