### PR TITLE
WIP - API: add API instructing Kurma to remotely fetch images

### DIFF
--- a/init/constants.go
+++ b/init/constants.go
@@ -22,6 +22,7 @@ var (
 		(*runner).runUdev,
 		(*runner).mountDisks,
 		(*runner).cleanOldPods,
+		(*runner).configureImageFetch,
 		(*runner).createImageManager,
 		(*runner).loadAvailableImages,
 		(*runner).createPodManager,

--- a/init/init.go
+++ b/init/init.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Apcera Inc. All rights reserved.
+// Copyright 2015-2016 Apcera Inc. All rights reserved.
 
 package init
 
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/apcera/kurma/pkg/backend"
+	"github.com/apcera/kurma/pkg/image"
 	"github.com/apcera/logray"
 )
 
@@ -13,11 +14,12 @@ import (
 // system. It will take of the running of the process once init.Run() is
 // invoked.
 type runner struct {
-	config         *kurmaConfig
-	log            *logray.Logger
-	podManager     backend.PodManager
-	imageManager   backend.ImageManager
-	networkManager backend.NetworkManager
+	config           *kurmaConfig
+	log              *logray.Logger
+	imageFetchConfig *image.FetchConfig
+	podManager       backend.PodManager
+	imageManager     backend.ImageManager
+	networkManager   backend.NetworkManager
 }
 
 // Run takes over the process and launches KurmaOS.

--- a/kurmad/kurmad.go
+++ b/kurmad/kurmad.go
@@ -105,8 +105,12 @@ func (ip *InitialPodManifest) Process(imageManager backend.ImageManager) (string
 
 	hash, imageManifest := imageManager.FindImage(ip.image, "")
 	if imageManifest == nil {
+		imageFetchCfg := &image.FetchConfig{
+			Insecure: true,
+		}
+
 		var err error
-		hash, imageManifest, err = image.FetchAndLoad(ip.image, nil, true, imageManager)
+		hash, imageManifest, err = imageFetchCfg.FetchAndLoad(ip.image, imageManager)
 		if err != nil {
 			return ip.name, nil, fmt.Errorf("failed to get a retrieve image %q: %v", ip.image, err)
 		}
@@ -200,6 +204,8 @@ func bootstrap(r setupRunner) error {
 	if err != nil {
 		return err
 	}
+
+	r.configureImageFetch()
 
 	err = r.createImageManager()
 	if err != nil {

--- a/kurmad/runner_test.go
+++ b/kurmad/runner_test.go
@@ -31,6 +31,7 @@ func (r *dummyFailRunner) loadConfigurationFile() error {
 }
 func (r *dummyFailRunner) configureLogging()         {}
 func (r *dummyFailRunner) createDirectories() error  { return nil }
+func (r *dummyFailRunner) configureImageFetch()      {}
 func (r *dummyFailRunner) createImageManager() error { return nil }
 func (r *dummyFailRunner) prefetchImages()           {}
 func (r *dummyFailRunner) createPodManager() error {
@@ -63,6 +64,7 @@ func (r *dummyOKRunner) setupSignalHandling()         {}
 func (r *dummyOKRunner) loadConfigurationFile() error { return nil }
 func (r *dummyOKRunner) configureLogging()            {}
 func (r *dummyOKRunner) createDirectories() error     { return nil }
+func (r *dummyOKRunner) configureImageFetch()         {}
 func (r *dummyOKRunner) createImageManager() error    { return nil }
 func (r *dummyOKRunner) prefetchImages()              {}
 func (r *dummyOKRunner) createPodManager() error      { return nil }

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -27,7 +27,7 @@ type Client interface {
 	DestroyPod(uuid string) error
 	EnterContainer(uuid string, appName string, app *schema.RunApp) (net.Conn, error)
 
-	FetchImage(imageURI string) (*Image, error)
+	FetchImage(imageURI string, fetchConfig *image.FetchConfig) (*Image, error)
 	CreateImage(reader io.Reader) (*Image, error)
 	ListImages() ([]*Image, error)
 	GetImage(hash string) (*Image, error)

--- a/pkg/apiclient/types.go
+++ b/pkg/apiclient/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
 
+	"github.com/apcera/kurma/pkg/image"
 	ntypes "github.com/apcera/kurma/pkg/networkmanager/types"
 	kschema "github.com/apcera/kurma/schema"
 )
@@ -52,6 +53,11 @@ type ContainerEnterResponse struct {
 
 type ImageListResponse struct {
 	Images []*Image `json:"images"`
+}
+
+type ImageFetchRequest struct {
+	ImageURI string `json:"image_uri"`
+	*image.FetchConfig
 }
 
 type ImageResponse struct {

--- a/pkg/apiproxy/image_service.go
+++ b/pkg/apiproxy/image_service.go
@@ -34,7 +34,7 @@ func (s *Server) imageFetchRequest(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
 
 	var imageFetchRequest *apiclient.ImageFetchRequest
-	if err := json.Unmarshal(req.Body, &imageFetchRequest); err != nil {
+	if err := json.NewDecoder(req.Body).Decode(&imageFetchRequest); err != nil {
 		s.log.Errorf("Failed to unmarshal request body: %s", err)
 		http.Error(w, "Failed to parse request body", http.StatusBadRequest)
 		return

--- a/pkg/apiproxy/image_service.go
+++ b/pkg/apiproxy/image_service.go
@@ -28,6 +28,30 @@ func (s *Server) imageCreateRequest(w http.ResponseWriter, req *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+// imageFetchRequest is a handler for requests instructing the daemon to fetch
+// and create a particular image.
+func (s *Server) imageFetchRequest(w http.ResponseWriter, req *http.Request) {
+	defer req.Body.Close()
+
+	var imageFetchRequest *apiclient.ImageFetchRequest
+	if err := json.Unmarshal(req.Body, &imageFetchRequest); err != nil {
+		s.log.Errorf("Failed to unmarshal request body: %s", err)
+		http.Error(w, "Failed to parse request body", http.StatusBadRequest)
+		return
+	}
+
+	image, err := s.client.FetchImage(imageFetchRequest.ImageURI, imageFetchRequest.FetchConfig)
+	if err != nil {
+		s.log.Errorf("Failed to fetch image %q: %s", imageFetchRequest.ImageURI, err)
+		http.Error(w, "Failed to fetch image", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	resp := &apiclient.ImageResponse{Image: image}
+	json.NewEncoder(w).Encode(resp)
+}
+
 func (s *ImageService) List(r *http.Request, args *apiclient.None, resp *apiclient.ImageListResponse) error {
 	images, err := s.server.client.ListImages()
 	if err != nil {

--- a/pkg/apiproxy/server.go
+++ b/pkg/apiproxy/server.go
@@ -65,6 +65,7 @@ func (s *Server) Start() error {
 	router.HandleFunc("/info", s.infoRequest).Methods("GET")
 	router.HandleFunc("/containers/enter", s.containerEnterRequest).Methods("GET")
 	router.HandleFunc("/images/create", s.imageCreateRequest).Methods("POST")
+	router.HandleFunc("/images/fetch", s.imageFetchRequest).Methods("POST")
 
 	s.log.Debug("Server is ready")
 	go func() {

--- a/pkg/cli/commands/create.go
+++ b/pkg/cli/commands/create.go
@@ -35,7 +35,7 @@ var (
 func init() {
 	cli.RootCmd.AddCommand(CreateCmd)
 	// TODO: insecure option should not be true by default.
-	CreateCmd.Flags().BoolVarP(&insecureFetch, "insecure", true, "pull without verifying signature or enforcing HTTPS")
+	CreateCmd.Flags().BoolVarP(&insecureFetch, "insecure", "", true, "pull without verifying signature or enforcing HTTPS")
 	CreateCmd.Flags().StringVarP(&createName, "name", "n", "", "pod's name")
 	CreateCmd.Flags().StringVarP(&createManifestFile, "manifest", "", "", "specific manifest to use")
 	CreateCmd.Flags().StringSliceVarP(&createNetworks, "net", "", []string{}, "network to attach to the pod")

--- a/pkg/cli/commands/fetch.go
+++ b/pkg/cli/commands/fetch.go
@@ -1,0 +1,43 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/apcera/kurma/pkg/cli"
+	"github.com/apcera/kurma/pkg/image"
+	"github.com/spf13/cobra"
+)
+
+var (
+	FetchCmd = &cobra.Command{
+		Use:   "fetch IMAGE_URI",
+		Short: "Instruct the Kurma daemon to remotely fetch and load an image",
+		Run:   cmdFetch,
+	}
+
+	insecureImageFetch bool
+)
+
+func init() {
+	cli.RootCmd.AddCommand(FetchCmd)
+	// TODO: insecure option should not be true by default.
+	FetchCmd.Flags().BoolVarP(&insecureFetch, "insecure", "", true, "pull without verifying signature or enforcing HTTPS")
+}
+
+func cmdFetch(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		cmd.Help()
+		os.Exit(1)
+	}
+
+	image, err := cli.GetClient().FetchImage(args[0], &image.FetchConfig{Insecure: insecureImageFetch})
+	if err != nil {
+		fmt.Printf("Failed to remotely fetch image %q: %s\n", req.ImageURI, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Fetched %q (%s)\n", req.ImageURI, image.Hash)
+}

--- a/pkg/daemon/image_service.go
+++ b/pkg/daemon/image_service.go
@@ -34,7 +34,8 @@ func (s *Server) imageFetchRequest(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
 
 	var imageFetchRequest *apiclient.ImageFetchRequest
-	if err := json.Unmarshal(req.Body, &imageFetchRequest); err != nil {
+
+	if err := json.NewDecoder(req.Body).Decode(&imageFetchRequest); err != nil {
 		s.log.Errorf("Failed to unmarshal request body: %s", err)
 		http.Error(w, "Failed to parse request body", http.StatusBadRequest)
 		return

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -85,6 +85,7 @@ func (s *Server) Start() error {
 	router.HandleFunc("/info", s.infoRequest).Methods("GET")
 	router.HandleFunc("/containers/enter", s.containerEnterRequest).Methods("GET")
 	router.HandleFunc("/images/create", s.imageCreateRequest).Methods("POST")
+	router.HandleFunc("/images/fetch", s.imageFetchRequest).Methods("POST")
 
 	s.log.Debug("Server is ready")
 	go func() {

--- a/pkg/image/fetch_test.go
+++ b/pkg/image/fetch_test.go
@@ -17,7 +17,9 @@ func TestFetch_LocalFile(t *testing.T) {
 
 	uri := "file://" + f.Name()
 
-	readers, err := Fetch(uri, nil, false)
+	fetchCfg := &FetchConfig{}
+
+	readers, err := fetchCfg.Fetch(uri)
 	if err != nil {
 		t.Fatalf("Expected no error retrieving %s; got %s", uri, err)
 	}
@@ -30,7 +32,9 @@ func TestFetch_LocalFile(t *testing.T) {
 func TestFetch_UnsupportedScheme(t *testing.T) {
 	uri := "fakescheme://google.com"
 
-	_, err := Fetch(uri, nil, false)
+	fetchCfg := &FetchConfig{}
+
+	_, err := fetchCfg.Fetch(uri)
 	if err == nil {
 		t.Fatalf("Expected error with URI %q, got none", uri)
 	}


### PR DESCRIPTION
Currently, Kurma fetches images through the client, then uploads them through the HTTP API to the backend. This PR adds an API (and CLI command) that can instruct the Kurma daemon to fetch a remote image and pre-load it for use later on.

Fixes #128

Putting this up for early review.

TODO:

- [ ] Not a huge name of `FetchConfig` name/usage
- [ ] Add integration tests
- [ ] Add unit tests
- [ ] Look for existing images before fetch server-side
- [ ] Look for existing images before fetch client-side?

@krobertson @mbhinder @wallyqs @jpoler 